### PR TITLE
add prefs node to chrome configuration

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
@@ -146,6 +146,7 @@ class Selenium2Factory implements DriverFactory
                         ->arrayNode('switches')->prototype('scalar')->end()->end()
                         ->scalarNode('binary')->end()
                         ->arrayNode('extensions')->prototype('scalar')->end()->end()
+                        ->arrayNode('prefs')->prototype('variable')->end()->end()
                     ->end()
                 ->end()
                 ->arrayNode('extra_capabilities')


### PR DESCRIPTION
It adds the capability to configure a new key 'prefs' to chrome configuration.
We need this to configure the default directory download of chrome.

> example:

    Behat\MinkExtension:
        sessions:
            chrome:
                selenium2:
                    browser: chrome
                    capabilities:
                        .....
                        chrome:
                            switches:
                                - "start-fullscreen"
                                - "start-maximized"
                                - "no-sandbox"
                                - "headless"
                            prefs:
                                download:
                                    default_directory: etc/downloads
