### PR TITLE
Support Symfony 3.4 (LTS)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^7.2",
         "behat/behat": "^3.0.5",
         "behat/mink": "^1.5",
-        "symfony/config": "^4.4|^5.0"
+        "symfony/config": "^3.4|^4.4|^5.0"
     },
 
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
     },
 
     "replace": {
-        "behat/mink-extension": "self.version",
-        "behat/mink-extension": "^2.0"
+        "behat/mink-extension": "self.version"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     },
 
     "replace": {
-        "behat/mink-extension": "self.version"
+        "behat/mink-extension": "self.version",
+        "behat/mink-extension": "^2.0"
     },
 
     "autoload": {


### PR DESCRIPTION
behatch/contexts relies on your fork (thanks for fixing PHP compability!), but in one project we still use Symfony 3.4 (LTS). This adds compatibility with that. 

Would be great if a minor version could be released with this so I can remove my fork that now publish a version we use with a repository override in composer.json
```
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/johanwilfer/MinkExtension"
        }
    ],
```