### PR TITLE
Prefer reflection method getType as getClass deprected as of PHP 8.0

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
@@ -116,7 +116,9 @@ class GoutteFactory implements DriverFactory
     {
         $refl = new \ReflectionParameter(array('Goutte\Client', 'setClient'), 0);
 
-        if ($refl->getClass() && 'Guzzle\Http\ClientInterface' === $refl->getClass()->getName()) {
+        if (method_exists($refl, 'getType') && 'Guzzle\Http\ClientInterface' == (string) $refl->getType()) {
+            return true;
+        } elseif ($refl->getClass() && 'Guzzle\Http\ClientInterface' === $refl->getClass()->getName()) {
             return true;
         }
 


### PR DESCRIPTION
Please consider releasing this quick patch supporting PHP upgrade. Thank you.
## ReflectionParameter::getClass
> Warning This function has been DEPRECATED as of PHP 8.0.0. Relying on this function is highly discouraged.

https://www.php.net/manual/en/reflectionparameter.getclass.php
https://www.php.net/manual/en/reflectionparameter.gettype.php