### PR TITLE
Marionette capability should be optional

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
@@ -98,7 +98,7 @@ class Selenium2Factory implements DriverFactory
                 ->scalarNode('platform')->end()
                 ->scalarNode('browserVersion')->end()
                 ->scalarNode('browser')->defaultValue('firefox')->end()
-                ->booleanNode('marionette')->defaultNull()->end()
+                ->booleanNode('marionette')->end()
                 ->booleanNode('ignoreZoomSetting')->defaultFalse()->end()
                 ->scalarNode('name')->defaultValue('Behat feature suite')->end()
                 ->scalarNode('deviceOrientation')->end()


### PR DESCRIPTION
The marionette capability is a Firefox-specific capability to aid in the
transition from legacy versions of Firefox (47.0.1 and earlier).

It is a `Boolean` and this value is now checked aggressively in Selenium
4.0.0 onwards. Since `null` is not a Boolean, this leads to an error.

This patch removes the default value, which means that if no value is
specified then it will not be included in the output, and the defaults
will apply (True for Firefox; Unset for other browsers).

Without this patch you must jump through hoops to run against Selenium
4.

Fixes #376