### PR TITLE
PHP 8.1 > Always pass `string` to `rtrim`

### DIFF
--- a/src/Behat/MinkExtension/Context/RawMinkContext.php
+++ b/src/Behat/MinkExtension/Context/RawMinkContext.php
@@ -141,7 +141,7 @@ class RawMinkContext implements MinkAwareContext
      */
     public function locatePath($path)
     {
-        $startUrl = rtrim($this->getMinkParameter('base_url'), '/') . '/';
+        $startUrl = rtrim($this->getMinkParameter('base_url') ?? '', '/') . '/';
 
         return 0 !== strpos($path, 'http') ? $startUrl . ltrim($path, '/') : $path;
     }


### PR DESCRIPTION
Fixes the following deprecation:
```
rtrim(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/friends-of-behat/mink-extension/src/Behat/MinkExtension/Context/RawMinkContext.php line 144
```
Please also tag a new patch release when this is merged 🙏 💙 