### PR TITLE
added: support to configure symfony http client parameters

### DIFF
--- a/src/Behat/MinkExtension/Context/MinkContext.php
+++ b/src/Behat/MinkExtension/Context/MinkContext.php
@@ -568,6 +568,6 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      */
     protected function fixStepArgument($argument)
     {
-        return str_replace('\\"', '"', $argument);
+        return is_null($argument) ? null : str_replace('\\"', '"', $argument);
     }
 }

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
@@ -64,8 +64,14 @@ class BrowserKitFactory implements DriverFactory
             throw new \RuntimeException(sprintf('Class %s not found, did you install symfony/browser-kit 4.4+?', HttpBrowser::class));
         }
 
+        $parameters[] = $config['http_client_parameters'] ?? [];
+
+        $httpClientDefinition = new Definition(NativeHttpClient::class, $parameters);
+
         return new Definition(BrowserKitDriver::class, [
-            new Definition(HttpBrowser::class),
+            new Definition(HttpBrowser::class, [
+                $httpClientDefinition
+            ]),
             '%mink.base_url%',
         ]);
     }

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
@@ -66,7 +66,7 @@ class BrowserKitFactory implements DriverFactory
 
         $parameters[] = $config['http_client_parameters'] ?? [];
 
-        $httpClientDefinition = new Definition(NativeHttpClient::class, $parameters);
+        $httpClientDefinition = new Definition(HttpClient::class, $parameters);
 
         return new Definition(BrowserKitDriver::class, [
             new Definition(HttpBrowser::class, [

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
@@ -13,7 +13,7 @@ use Behat\Mink\Driver\BrowserKitDriver;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\BrowserKit\HttpBrowser;
-use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\NativeHttpClient;
 
 
 class BrowserKitFactory implements DriverFactory

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
@@ -39,6 +39,14 @@ class BrowserKitFactory implements DriverFactory
      */
     public function configure(ArrayNodeDefinition $builder)
     {
+        $builder
+            ->children()
+                ->arrayNode('http_client_parameters')
+                    ->useAttributeAsKey('key')
+                    ->prototype('variable')->end()
+                ->info('Set parameters on HttpClient (see https://symfony.com/doc/current/reference/configuration/framework.html#http-client)')
+                ->end()
+            ->end();
     }
 
     /**

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
@@ -57,7 +57,7 @@ class BrowserKitFactory implements DriverFactory
         if (!class_exists(BrowserKitDriver::class)) {
             throw new \RuntimeException('Install behat/mink-browserkit-driver in order to use the browserkit_http driver.');
         }
-        if (!class_exists(HttpClient::class)) {
+        if (!class_exists(NativeHttpClient::class)) {
             throw new \RuntimeException(sprintf('Class %s not found, did you install symfony/http-client?', HttpClient::class));
         }
         if (!class_exists(HttpBrowser::class)) {
@@ -66,7 +66,7 @@ class BrowserKitFactory implements DriverFactory
 
         $parameters[] = $config['http_client_parameters'] ?? [];
 
-        $httpClientDefinition = new Definition(HttpClient::class, $parameters);
+        $httpClientDefinition = new Definition(NativeHttpClient::class, $parameters);
 
         return new Definition(BrowserKitDriver::class, [
             new Definition(HttpBrowser::class, [


### PR DESCRIPTION
Had an issue with SSL certificate problems when trying to run my tests locally using `BrowserKitFactory.php`. We have a self-signed certificate locally and unless it's added to the system store the Symfony HttpClient will say there's a certificate problem.

Symfony offers us config options with `http_client` to disable `verify_host` and `verify_peer`.

This PR adds the ability to configure these `http_client` options inside the `browserkit_http` driver.

These changes were done by @acsauk over in his own fork here: https://github.com/FriendsOfBehat/MinkExtension/compare/master...acsauk:MinkExtension:master#diff-f973be034feb9afd968a2139eb090d22a81cdd3cfa572dac6d93836a5785b4c9R40-R51

I feel like it would be beneficial for the changes to be over in this forked repo as others might need the ability to disable the verify options on the HttpClient and then there is one less place to maintain the repo also