### PR TITLE
Compatibility with guzzle 7.

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
@@ -10,6 +10,7 @@
 
 namespace Behat\MinkExtension\ServiceContainer\Driver;
 
+use GuzzleHttp\ClientInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -148,7 +149,18 @@ class GoutteFactory implements DriverFactory
 
     private function isGuzzle6()
     {
-        return interface_exists('GuzzleHttp\ClientInterface') &&
-            version_compare(\GuzzleHttp\ClientInterface::VERSION, '6.0.0', '>=');
+        if (!interface_exists(ClientInterface::class)) {
+            return false;
+        }
+        $rc = new \ReflectionClass(ClientInterface::class);
+        // This constant was removed in Guzzle 7.
+        if ($rc->hasConstant('VERSION')) {
+            return version_compare(ClientInterface::VERSION, '6.0.0', '>=');
+        }
+        // This constant was added in Guzzle 7.
+        if ($rc->hasConstant('MAJOR_VERSION')) {
+            ClientInterface::MAJOR_VERSION >= 6;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
The ClientInterface::VERSION no longer exists in Guzzle 7.
This PR is a proof of concept, I do not claim that this is the ultimate way to deal with this.



_I accidentally created this in the wrong repo first: https://g_ithub.com/Behat/MinkExtension/pull/387.
I now see that this repo is more up to date, and is in fact what I am using in my project._