### PR TITLE
Correct BrowserKitFactory to support the 'http_client_parameters' option

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
@@ -39,6 +39,15 @@ class BrowserKitFactory implements DriverFactory
      */
     public function configure(ArrayNodeDefinition $builder)
     {
+        $builder
+            ->children()
+                ->arrayNode('http_client_parameters')
+                    ->useAttributeAsKey('key')
+                    ->prototype('variable')->end()
+                ->info('Set parameters on HttpClient (see https://symfony.com/doc/current/reference/configuration/framework.html#http-client)')
+                ->end()
+            ->end()
+        ;
     }
 
     /**


### PR DESCRIPTION
Follow up to #22.

A new option to configure the BrowserKitDriver client was added in the previous PR, however, the configuration could not be added to the configuration file as it would return the following error: Unrecognized option "http_client_parameters".
This PR allows the use of the option, for exemple:
```yaml
default:
  suites:
    default:
      path: "%paths.base%/features"
      contexts: [Behat\MinkExtension\Context\MinkContext]
  extensions:
    Behat\MinkExtension:
      base_url: http://en.wikipedia.org/
      sessions:
        default:
          browserkit_http:
            http_client_parameters:
                verify_host: false
                verify_peer: false
```