### PR TITLE
Better DX error handling when misuse of SymfonyExtension config

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php
+++ b/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php
@@ -117,7 +117,7 @@ class MinkExtension implements ExtensionInterface
                 ->always()
                 ->then(function ($v) use ($renamedKeys) {
                     foreach ($renamedKeys as $driverType) {
-                        if (!array_key_exists($driverType, $v) || isset($v['sessions'][$driverType])) {
+                        if (!array_key_exists($driverType, (array)$v) || isset($v['sessions'][$driverType])) {
                             continue;
                         }
 


### PR DESCRIPTION
### Issue
As a dummy symfony user, when I don't use the `MinkExtension` correctly with the following config
```yml
# behat.yml.dist
...
    extensions:
        Behat\MinkExtension: ~   # <---- empty invalid config
```
we have the following PHP fatal error :
```
PHP Fatal error: Uncaught TypeError: array_key_exists():
Argument #2 ($array) must be of type array, null given in MinkExtension.php:120
```

### Reproduce
```
composer create-project symfony/symfony-demo mink-reproduce-bug
cd ./mink-reproduce-bug
composer require --dev behat/behat friends-of-behat/symfony-extension friends-of-behat/mink-extension
echo "        Behat\MinkExtension: ~" >> behat.yml.dist
vendor/bin/behat
```

### Solution
Checking that the config is an array, so we get this error instead :
![mink](https://github.com/FriendsOfBehat/MinkExtension/assets/8001284/f5618fa1-7121-435e-8a01-2c7edc195760)
