### PR TITLE
Prepare for Symfomy 8.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
         "php": "^7.4 || ^8",
         "behat/behat": "^3.0.5",
         "behat/mink": "^1.5",
-        "symfony/config": "^4.4 || ^5.0 || ^6.0 || ^7.0"
+        "symfony/config": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "behat/mink-goutte-driver": "^1.1 || ^2.0",

--- a/src/Behat/MinkExtension/Listener/FailureShowListener.php
+++ b/src/Behat/MinkExtension/Listener/FailureShowListener.php
@@ -43,7 +43,7 @@ class FailureShowListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             StepTested::AFTER => array('showFailedStepResponse', -10)

--- a/src/Behat/MinkExtension/Listener/SessionsListener.php
+++ b/src/Behat/MinkExtension/Listener/SessionsListener.php
@@ -56,7 +56,7 @@ class SessionsListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             ScenarioTested::BEFORE   => array('prepareDefaultMinkSession', 10),

--- a/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php
+++ b/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php
@@ -190,7 +190,7 @@ class MinkExtension implements ExtensionInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processSelectors($container);
     }


### PR DESCRIPTION
Symfony 8 added return types to all interfaces and classes. This leaks through the Behat API in places where Behat used classes from Symfony, for example the Event Dispatcher implementation or the `\Behat\Testwork\ServiceContainer\Extension` interface which extends `\Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface`.

The Behat maintainers work on creating a new Behat release supporting Symfony 8, but it will also affect extensions like this one (https://github.com/Behat/Behat/pull/1687).

Technically, this may be a BC break for people that extend the classes provided here (they're not final), but on the other hand, these classes were never meant to be an extension point in the first place.