### PR TITLE
Mark Goutte, Selenium, Sahi and Zombie driver/support as abandoned

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,3 +9,18 @@ This document summarizes the changes relevant for users when upgrading to new ve
 The classes `FailureShowListener`, `SessionsListener` and `MinkExtension` have been marked as `@final`. They will become `final` classes in the next major release and you will no longer be able to use them by inheritance (https://github.com/FriendsOfBehat/MinkExtension/pull/41).
 
 Additionally, the two listener classes have been marked as `@internal`. Starting with the next major version, their API may change at any time without further notice.
+
+## Deprecated drivers
+
+Support for the following drivers has been deprecated, since the underlying driver implementations have been abandoned:
+
+- GoutteDriver
+- SeleniumDriver
+- SahiDriver
+- ZombieDriver
+
+The corresponding `Factory` classes will trigger a deprecation notice when they are used to build the driver, for example
+by using `goutte` as the driver identifier in the `behat.yml` configuration file (https://github.com/FriendsOfBehat/MinkExtension/pull/39/).
+
+Note, however, that Behat currently does not have a built-in mechanism to collect such deprecation notices and display
+them in a user-friendly way.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "php": "^7.4 || ^8",
         "behat/behat": "^3.0.5",
         "behat/mink": "^1.5",
-        "symfony/config": "^4.4 || ^5.0 || ^6.0 || ^7.0"
+        "symfony/config": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/deprecation-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "behat/mink-goutte-driver": "^1.1 || ^2.0",

--- a/doc/index.md
+++ b/doc/index.md
@@ -174,6 +174,10 @@ with support for 7 drivers out of the box:
 * `GoutteDriver` - headless driver without JavaScript support. In order to use
   it, modify your `behat.yml` profile:
 
+> [!IMPORTANT]
+> Support for this driver has been deprecated, since the driver package has been abandoned.
+> It will be removed in the next major version of this extension.
+
     ```yaml
     default:
         extensions:
@@ -256,6 +260,10 @@ with support for 7 drivers out of the box:
 * `SeleniumDriver` - javascript driver. In order to use it, modify your `behat.yml`
   profile:
 
+> [!IMPORTANT]
+> Support for this driver has been deprecated, since the driver package has been abandoned.
+> It will be removed in the next major version of this extension.
+
     ```yaml
     default:
         extensions:
@@ -268,6 +276,10 @@ with support for 7 drivers out of the box:
 * `SahiDriver` - javascript driver. In order to use it, modify your `behat.yml`
   profile:
 
+> [!IMPORTANT]
+> Support for this driver has been deprecated, since the driver package has been abandoned.
+> It will be removed in the next major version of this extension.
+
     ```yaml
     default:
         extensions:
@@ -279,6 +291,10 @@ with support for 7 drivers out of the box:
 
 * `ZombieDriver` - zombie.js javascript headless driver. In order to use it, modify
   your `behat.yml` profile:
+
+> [!IMPORTANT]
+> Support for this driver has been deprecated, since the driver package has been abandoned.
+> It will be removed in the next major version of this extension.
 
     ```yaml
     default:

--- a/doc/index.md
+++ b/doc/index.md
@@ -174,9 +174,9 @@ with support for 7 drivers out of the box:
 * `GoutteDriver` - headless driver without JavaScript support. In order to use
   it, modify your `behat.yml` profile:
 
-> [!IMPORTANT]
-> Support for this driver has been deprecated, since the driver package has been abandoned.
-> It will be removed in the next major version of this extension.
+    > [!IMPORTANT]
+    > Support for this driver has been deprecated, since the driver package has been abandoned.
+    > It will be removed in the next major version of this extension.
 
     ```yaml
     default:
@@ -260,9 +260,9 @@ with support for 7 drivers out of the box:
 * `SeleniumDriver` - javascript driver. In order to use it, modify your `behat.yml`
   profile:
 
-> [!IMPORTANT]
-> Support for this driver has been deprecated, since the driver package has been abandoned.
-> It will be removed in the next major version of this extension.
+    > [!IMPORTANT]
+    > Support for this driver has been deprecated, since the driver package has been abandoned.
+    > It will be removed in the next major version of this extension.
 
     ```yaml
     default:
@@ -276,9 +276,9 @@ with support for 7 drivers out of the box:
 * `SahiDriver` - javascript driver. In order to use it, modify your `behat.yml`
   profile:
 
-> [!IMPORTANT]
-> Support for this driver has been deprecated, since the driver package has been abandoned.
-> It will be removed in the next major version of this extension.
+    > [!IMPORTANT]
+    > Support for this driver has been deprecated, since the driver package has been abandoned.
+    > It will be removed in the next major version of this extension.
 
     ```yaml
     default:
@@ -292,9 +292,9 @@ with support for 7 drivers out of the box:
 * `ZombieDriver` - zombie.js javascript headless driver. In order to use it, modify
   your `behat.yml` profile:
 
-> [!IMPORTANT]
-> Support for this driver has been deprecated, since the driver package has been abandoned.
-> It will be removed in the next major version of this extension.
+    > [!IMPORTANT]
+    > Support for this driver has been deprecated, since the driver package has been abandoned.
+    > It will be removed in the next major version of this extension.
 
     ```yaml
     default:

--- a/doc/index.md
+++ b/doc/index.md
@@ -85,10 +85,10 @@ After installing the extension, there are 4 usage options available:
     }
     ```
 
-> [!NOTE]
-> Keep in mind, that you can not have multiple step definitions with the same regex.
-> It will cause a `RedundantException`. So, you can inherit from `MinkContext`
-> only with one of your context/subcontext classes.
+    > [!NOTE]
+    > Keep in mind, that you can not have multiple step definitions with the same regex.
+    > It will cause a `RedundantException`. So, you can inherit from `MinkContext`
+    > only with one of your context/subcontext classes.
 
 3. Adding `Behat\MinkExtension\Context\MinkContext` as a context in your suite.
    Exactly like the previous option, but gives you the ability to keep your main context
@@ -103,10 +103,10 @@ After installing the extension, there are 4 usage options available:
             - Behat\MinkExtension\Context\MinkContext
     ```
 
-> [!NOTE]
-> Keep in mind, that you can not have multiple step definitions with the same regex.
-> It will cause a `RedundantException`. So, you can inherit from `MinkContext`
-> only with one of your context/subcontext classes.
+    > [!NOTE]
+    > Keep in mind, that you can not have multiple step definitions with the same regex.
+    > It will cause a `RedundantException`. So, you can inherit from `MinkContext`
+    > only with one of your context/subcontext classes.
 
 4. Implementing `Behat\MinkExtension\Context\MinkAwareContext` with your context.
 

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
@@ -62,6 +62,8 @@ class GoutteFactory implements DriverFactory
      */
     public function buildDriver(array $config)
     {
+        trigger_deprecation('friends-of-behat/mink-extension', '2.8.0', 'Configuration for the "goutte" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of this extension.');
+
         if (!class_exists('Behat\Mink\Driver\GoutteDriver')) {
             throw new \RuntimeException(
                 'Install MinkGoutteDriver in order to use goutte driver.'

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/SahiFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/SahiFactory.php
@@ -52,6 +52,8 @@ class SahiFactory implements DriverFactory
      */
     public function buildDriver(array $config)
     {
+        trigger_deprecation('friends-of-behat/mink-extension', '2.8.0', 'Configuration for the "sahi" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of this extension.');
+
         if (!class_exists('Behat\Mink\Driver\SahiDriver')) {
             throw new \RuntimeException(
                 'Install MinkSahiDriver in order to use sahi driver.'

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/SeleniumFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/SeleniumFactory.php
@@ -50,6 +50,8 @@ class SeleniumFactory implements DriverFactory
      */
     public function buildDriver(array $config)
     {
+        trigger_deprecation('friends-of-behat/mink-extension', '2.8.0', 'Configuration for the "selenium" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of this extension.');
+
         if (!class_exists('Behat\Mink\Driver\SeleniumDriver')) {
             throw new \RuntimeException(
                 'Install MinkSeleniumDriver in order to activate selenium session.'

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/ZombieFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/ZombieFactory.php
@@ -53,6 +53,8 @@ class ZombieFactory implements DriverFactory
      */
     public function buildDriver(array $config)
     {
+        trigger_deprecation('friends-of-behat/mink-extension', '2.8.0', 'Configuration for the "zombie" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of this extension.');
+
         if (!class_exists('Behat\Mink\Driver\ZombieDriver')) {
             throw new \RuntimeException(
                 'Install MinkZombieDriver in order to use zombie driver.'


### PR DESCRIPTION
~Goutte has been abandoned a long time ago, and its dependencies pose a burden here.~ 

~Let's get rid of it.~ 

~Since we're not providing a replacement, maybe this need not be merged in the next minor release, but can go anywhere? In that case, I'd need to update the version number.~ 

This marks the four drivers as abandoned where the driver implementations are no longer maintained.