### PR TITLE
Soft-finalize classes that might need to be changed in the future

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,12 @@
+# Upgrade notes for FriendsOfBehat/MinkExtension
+
+This document summarizes the changes relevant for users when upgrading to new versions.
+
+# Upgrade to 2.8
+
+## Soft `@final` declarations added
+
+The classes `FailureShowListener`, `SessionsListener` and `MinkExtension` have been marked as `@final`.
+
+They will become `final` classes in the next major release and you will no longer be able to use them
+by inheritance (https://github.com/FriendsOfBehat/MinkExtension/pull/41).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,9 +4,8 @@ This document summarizes the changes relevant for users when upgrading to new ve
 
 # Upgrade to 2.8
 
-## Soft `@final` declarations added
+## Soft `@final` and `@internal` declarations added
 
-The classes `FailureShowListener`, `SessionsListener` and `MinkExtension` have been marked as `@final`.
+The classes `FailureShowListener`, `SessionsListener` and `MinkExtension` have been marked as `@final`. They will become `final` classes in the next major release and you will no longer be able to use them by inheritance (https://github.com/FriendsOfBehat/MinkExtension/pull/41).
 
-They will become `final` classes in the next major release and you will no longer be able to use them
-by inheritance (https://github.com/FriendsOfBehat/MinkExtension/pull/41).
+Additionally, the two listener classes have been marked as `@internal`. Starting with the next major version, their API may change at any time without further notice.

--- a/src/Behat/MinkExtension/Listener/FailureShowListener.php
+++ b/src/Behat/MinkExtension/Listener/FailureShowListener.php
@@ -24,6 +24,7 @@ use Behat\Mink\Exception\Exception as MinkException;
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * @final since 2.8.0
+ * @internal since 2.8.0
  */
 class FailureShowListener implements EventSubscriberInterface
 {

--- a/src/Behat/MinkExtension/Listener/FailureShowListener.php
+++ b/src/Behat/MinkExtension/Listener/FailureShowListener.php
@@ -22,6 +22,8 @@ use Behat\Mink\Exception\Exception as MinkException;
  * Listens to failed Behat steps and shows last response in a browser.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @final since 2.8.0
  */
 class FailureShowListener implements EventSubscriberInterface
 {

--- a/src/Behat/MinkExtension/Listener/SessionsListener.php
+++ b/src/Behat/MinkExtension/Listener/SessionsListener.php
@@ -25,6 +25,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * Listens Behat events and configures/stops Mink sessions.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @final since 2.8.0
  */
 class SessionsListener implements EventSubscriberInterface
 {

--- a/src/Behat/MinkExtension/Listener/SessionsListener.php
+++ b/src/Behat/MinkExtension/Listener/SessionsListener.php
@@ -27,6 +27,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * @final since 2.8.0
+ * @internal since 2.8.0
  */
 class SessionsListener implements EventSubscriberInterface
 {

--- a/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php
+++ b/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php
@@ -38,6 +38,8 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @final since 2.8.0
  */
 class MinkExtension implements ExtensionInterface
 {


### PR DESCRIPTION
We might need to change some classes in the near future (https://github.com/FriendsOfBehat/MinkExtension/pull/37).

I think these classes were never really meant to be extension points, so let's soft-declare them as final now.

Even more, the listeners are internal and should not be used at all. Regarding the `MinkExtension`, other packages might want to use it to register their own drivers.