### PR TITLE
Use attributes instead of annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "homepage": "https://github.com/FriendsOfBehat/MinkExtension#readme",
     "require": {
         "php": "^7.4 || ^8",
-        "behat/behat": "^3.0.5",
+        "behat/behat": "^3.10",
         "behat/mink": "^1.5",
         "symfony/config": "^4.4 || ^5.0 || ^6.0 || ^7.0"
     },

--- a/src/Behat/MinkExtension/Context/MinkContext.php
+++ b/src/Behat/MinkExtension/Context/MinkContext.php
@@ -12,6 +12,9 @@ namespace Behat\MinkExtension\Context;
 
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 /**
  * Mink context for Behat BDD tool.
@@ -26,10 +29,9 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Example: Given I am on "/"
      * Example: When I go to "/"
      * Example: And I go to "/"
-     *
-     * @Given /^(?:|I )am on (?:|the )homepage$/
-     * @When /^(?:|I )go to (?:|the )homepage$/
      */
+    #[Given('/^(?:|I )am on (?:|the )homepage$/')]
+    #[When('/^(?:|I )go to (?:|the )homepage$/')]
     public function iAmOnHomepage()
     {
         $this->visitPath('/');
@@ -40,10 +42,9 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Example: Given I am on "http://batman.com"
      * Example: And I am on "/articles/isBatmanBruceWayne"
      * Example: When I go to "/articles/isBatmanBruceWayne"
-     *
-     * @Given /^(?:|I )am on "(?P<page>[^"]+)"$/
-     * @When /^(?:|I )go to "(?P<page>[^"]+)"$/
      */
+    #[Given('/^(?:|I )am on "(?P<page>[^"]+)"$/')]
+    #[When('/^(?:|I )go to "(?P<page>[^"]+)"$/')]
     public function visit($page)
     {
         $this->visitPath($page);
@@ -53,9 +54,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Reloads current page
      * Example: When I reload the page
      * Example: And I reload the page
-     *
-     * @When /^(?:|I )reload the page$/
      */
+    #[When('/^(?:|I )reload the page$/')]
     public function reload()
     {
         $this->getSession()->reload();
@@ -64,9 +64,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
     /**
      * Moves backward one page in history
      * Example: When I move backward one page
-     *
-     * @When /^(?:|I )move backward one page$/
      */
+    #[When('/^(?:|I )move backward one page$/')]
     public function back()
     {
         $this->getSession()->back();
@@ -75,9 +74,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
     /**
      * Moves forward one page in history
      * Example: And I move forward one page
-     *
-     * @When /^(?:|I )move forward one page$/
      */
+    #[When('/^(?:|I )move forward one page$/')]
     public function forward()
     {
         $this->getSession()->forward();
@@ -87,9 +85,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Presses button with specified id|name|title|alt|value
      * Example: When I press "Log In"
      * Example: And I press "Log In"
-     *
-     * @When /^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/
      */
+    #[When('/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/')]
     public function pressButton($button)
     {
         $button = $this->fixStepArgument($button);
@@ -100,9 +97,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Clicks link with specified id|title|alt|text
      * Example: When I follow "Log In"
      * Example: And I follow "Log In"
-     *
-     * @When /^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/
      */
+    #[When('/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/')]
     public function clickLink($link)
     {
         $link = $this->fixStepArgument($link);
@@ -113,11 +109,10 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Fills in form field with specified id|name|label|value
      * Example: When I fill in "username" with: "bwayne"
      * Example: And I fill in "bwayne" for "username"
-     *
-     * @When /^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/
-     * @When /^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with:$/
-     * @When /^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/
      */
+    #[When('/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/')]
+    #[When('/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with:$/')]
+    #[When('/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/')]
     public function fillField($field, $value)
     {
         $field = $this->fixStepArgument($field);
@@ -133,9 +128,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Example: And I fill in the following"
      *              | username | bruceWayne |
      *              | password | iLoveBats123 |
-     *
-     * @When /^(?:|I )fill in the following:$/
      */
+    #[When('/^(?:|I )fill in the following:$/')]
     public function fillFields(TableNode $fields)
     {
         foreach ($fields->getRowsHash() as $field => $value) {
@@ -147,9 +141,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Selects option in select field with specified id|name|label|value
      * Example: When I select "Bats" from "user_fears"
      * Example: And I select "Bats" from "user_fears"
-     *
-     * @When /^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/
      */
+    #[When('/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/')]
     public function selectOption($select, $option)
     {
         $select = $this->fixStepArgument($select);
@@ -161,9 +154,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Selects additional option in select field with specified id|name|label|value
      * Example: When I additionally select "Deceased" from "parents_alive_status"
      * Example: And I additionally select "Deceased" from "parents_alive_status"
-     *
-     * @When /^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/
      */
+    #[When('/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/')]
     public function additionallySelectOption($select, $option)
     {
         $select = $this->fixStepArgument($select);
@@ -175,9 +167,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks checkbox with specified id|name|label|value
      * Example: When I check "Pearl Necklace"
      * Example: And I check "Pearl Necklace"
-     *
-     * @When /^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/
      */
+    #[When('/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/')]
     public function checkOption($option)
     {
         $option = $this->fixStepArgument($option);
@@ -188,9 +179,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Unchecks checkbox with specified id|name|label|value
      * Example: When I uncheck "Broadway Plays"
      * Example: And I uncheck "Broadway Plays"
-     *
-     * @When /^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/
      */
+    #[When('/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/')]
     public function uncheckOption($option)
     {
         $option = $this->fixStepArgument($option);
@@ -201,9 +191,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Attaches file to field with specified id|name|label|value
      * Example: When I attach the file "bwayne_profile.png" to "profileImageUpload"
      * Example: And I attach the file "bwayne_profile.png" to "profileImageUpload"
-     *
-     * @When /^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/
      */
+    #[When('/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/')]
     public function attachFileToField($field, $path)
     {
         $field = $this->fixStepArgument($field);
@@ -223,9 +212,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Example: Then I should be on "/"
      * Example: And I should be on "/bats"
      * Example: And I should be on "http://google.com"
-     *
-     * @Then /^(?:|I )should be on "(?P<page>[^"]+)"$/
      */
+    #[Then('/^(?:|I )should be on "(?P<page>[^"]+)"$/')]
     public function assertPageAddress($page)
     {
         $this->assertSession()->addressEquals($this->locatePath($page));
@@ -235,9 +223,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that current page is the homepage
      * Example: Then I should be on the homepage
      * Example: And I should be on the homepage
-     *
-     * @Then /^(?:|I )should be on (?:|the )homepage$/
      */
+    #[Then('/^(?:|I )should be on (?:|the )homepage$/')]
     public function assertHomepage()
     {
         $this->assertSession()->addressEquals($this->locatePath('/'));
@@ -248,9 +235,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Example: Then the url should match "superman is dead"
      * Example: Then the uri should match "log in"
      * Example: And the url should match "log in"
-     *
-     * @Then /^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/
      */
+    #[Then('/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/')]
     public function assertUrlRegExp($pattern)
     {
         $this->assertSession()->addressMatches($this->fixStepArgument($pattern));
@@ -260,9 +246,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that current page response status is equal to specified
      * Example: Then the response status code should be 200
      * Example: And the response status code should be 400
-     *
-     * @Then /^the response status code should be (?P<code>\d+)$/
      */
+    #[Then('/^the response status code should be (?P<code>\d+)$/')]
     public function assertResponseStatus($code)
     {
         $this->assertSession()->statusCodeEquals($code);
@@ -272,9 +257,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that current page response status is not equal to specified
      * Example: Then the response status code should not be 501
      * Example: And the response status code should not be 404
-     *
-     * @Then /^the response status code should not be (?P<code>\d+)$/
      */
+    #[Then('/^the response status code should not be (?P<code>\d+)$/')]
     public function assertResponseStatusIsNot($code)
     {
         $this->assertSession()->statusCodeNotEquals($code);
@@ -284,9 +268,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that page contains specified text
      * Example: Then I should see "Who is the Batman?"
      * Example: And I should see "Who is the Batman?"
-     *
-     * @Then /^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/
      */
+    #[Then('/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/')]
     public function assertPageContainsText($text)
     {
         $this->assertSession()->pageTextContains($this->fixStepArgument($text));
@@ -296,9 +279,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that page doesn't contain specified text
      * Example: Then I should not see "Batman is Bruce Wayne"
      * Example: And I should not see "Batman is Bruce Wayne"
-     *
-     * @Then /^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/
      */
+    #[Then('/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/')]
     public function assertPageNotContainsText($text)
     {
         $this->assertSession()->pageTextNotContains($this->fixStepArgument($text));
@@ -308,9 +290,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that page contains text matching specified pattern
      * Example: Then I should see text matching "Batman, the vigilante"
      * Example: And I should not see "Batman, the vigilante"
-     *
-     * @Then /^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/
      */
+    #[Then('/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/')]
     public function assertPageMatchesText($pattern)
     {
         $this->assertSession()->pageTextMatches($this->fixStepArgument($pattern));
@@ -320,9 +301,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that page doesn't contain text matching specified pattern
      * Example: Then I should see text matching "Bruce Wayne, the vigilante"
      * Example: And I should not see "Bruce Wayne, the vigilante"
-     *
-     * @Then /^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/
      */
+    #[Then('/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/')]
     public function assertPageNotMatchesText($pattern)
     {
         $this->assertSession()->pageTextNotMatches($this->fixStepArgument($pattern));
@@ -332,9 +312,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that HTML response contains specified string
      * Example: Then the response should contain "Batman is the hero Gotham deserves."
      * Example: And the response should contain "Batman is the hero Gotham deserves."
-     *
-     * @Then /^the response should contain "(?P<text>(?:[^"]|\\")*)"$/
      */
+    #[Then('/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/')]
     public function assertResponseContains($text)
     {
         $this->assertSession()->responseContains($this->fixStepArgument($text));
@@ -344,9 +323,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that HTML response doesn't contain specified string
      * Example: Then the response should not contain "Bruce Wayne is a billionaire, play-boy, vigilante."
      * Example: And the response should not contain "Bruce Wayne is a billionaire, play-boy, vigilante."
-     *
-     * @Then /^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/
      */
+    #[Then('/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/')]
     public function assertResponseNotContains($text)
     {
         $this->assertSession()->responseNotContains($this->fixStepArgument($text));
@@ -356,9 +334,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that element with specified CSS contains specified text
      * Example: Then I should see "Batman" in the "heroes_list" element
      * Example: And I should see "Batman" in the "heroes_list" element
-     *
-     * @Then /^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/
      */
+    #[Then('/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/')]
     public function assertElementContainsText($element, $text)
     {
         $this->assertSession()->elementTextContains('css', $element, $this->fixStepArgument($text));
@@ -368,9 +345,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that element with specified CSS doesn't contain specified text
      * Example: Then I should not see "Bruce Wayne" in the "heroes_alter_egos" element
      * Example: And I should not see "Bruce Wayne" in the "heroes_alter_egos" element
-     *
-     * @Then /^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/
      */
+    #[Then('/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/')]
     public function assertElementNotContainsText($element, $text)
     {
         $this->assertSession()->elementTextNotContains('css', $element, $this->fixStepArgument($text));
@@ -380,9 +356,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that element with specified CSS contains specified HTML
      * Example: Then the "body" element should contain "style=\"color:black;\""
      * Example: And the "body" element should contain "style=\"color:black;\""
-     *
-     * @Then /^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/
      */
+    #[Then('/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/')]
     public function assertElementContains($element, $value)
     {
         $this->assertSession()->elementContains('css', $element, $this->fixStepArgument($value));
@@ -392,9 +367,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that element with specified CSS doesn't contain specified HTML
      * Example: Then the "body" element should not contain "style=\"color:black;\""
      * Example: And the "body" element should not contain "style=\"color:black;\""
-     *
-     * @Then /^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\\")*)"$/
      */
+    #[Then('/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\\")*)"$/')]
     public function assertElementNotContains($element, $value)
     {
         $this->assertSession()->elementNotContains('css', $element, $this->fixStepArgument($value));
@@ -404,9 +378,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that element with specified CSS exists on page
      * Example: Then I should see a "body" element
      * Example: And I should see a "body" element
-     *
-     * @Then /^(?:|I )should see an? "(?P<element>[^"]*)" element$/
      */
+    #[Then('/^(?:|I )should see an? "(?P<element>[^"]*)" element$/')]
     public function assertElementOnPage($element)
     {
         $this->assertSession()->elementExists('css', $element);
@@ -416,9 +389,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that element with specified CSS doesn't exist on page
      * Example: Then I should not see a "canvas" element
      * Example: And I should not see a "canvas" element
-     *
-     * @Then /^(?:|I )should not see an? "(?P<element>[^"]*)" element$/
      */
+    #[Then('/^(?:|I )should not see an? "(?P<element>[^"]*)" element$/')]
     public function assertElementNotOnPage($element)
     {
         $this->assertSession()->elementNotExists('css', $element);
@@ -428,9 +400,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that form field with specified id|name|label|value has specified value
      * Example: Then the "username" field should contain "bwayne"
      * Example: And the "username" field should contain "bwayne"
-     *
-     * @Then /^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/
      */
+    #[Then('/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/')]
     public function assertFieldContains($field, $value)
     {
         $field = $this->fixStepArgument($field);
@@ -442,9 +413,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that form field with specified id|name|label|value doesn't have specified value
      * Example: Then the "username" field should not contain "batman"
      * Example: And the "username" field should not contain "batman"
-     *
-     * @Then /^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/
      */
+    #[Then('/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/')]
     public function assertFieldNotContains($field, $value)
     {
         $field = $this->fixStepArgument($field);
@@ -456,9 +426,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that (?P<num>\d+) CSS elements exist on the page
      * Example: Then I should see 5 "div" elements
      * Example: And I should see 5 "div" elements
-     *
-     * @Then /^(?:|I )should see (?P<num>\d+) "(?P<element>[^"]*)" elements?$/
      */
+    #[Then('/^(?:|I )should see (?P<num>\d+) "(?P<element>[^"]*)" elements?$/')]
     public function assertNumElements($num, $element)
     {
         $this->assertSession()->elementsCount('css', $element, intval($num));
@@ -468,11 +437,10 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Checks, that checkbox with specified id|name|label|value is checked
      * Example: Then the "remember_me" checkbox should be checked
      * Example: And the "remember_me" checkbox is checked
-     *
-     * @Then /^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/
-     * @Then /^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox is checked$/
-     * @Then /^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" (?:is|should be) checked$/
      */
+    #[Then('/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/')]
+    #[Then('/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox is checked$/')]
+    #[Then('/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" (?:is|should be) checked$/')]
     public function assertCheckboxChecked($checkbox)
     {
         $this->assertSession()->checkboxChecked($this->fixStepArgument($checkbox));
@@ -483,12 +451,11 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Example: Then the "newsletter" checkbox should be unchecked
      * Example: Then the "newsletter" checkbox should not be checked
      * Example: And the "newsletter" checkbox is unchecked
-     *
-     * @Then /^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should (?:be unchecked|not be checked)$/
-     * @Then /^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox is (?:unchecked|not checked)$/
-     * @Then /^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" should (?:be unchecked|not be checked)$/
-     * @Then /^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" is (?:unchecked|not checked)$/
      */
+    #[Then('/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should (?:be unchecked|not be checked)$/')]
+    #[Then('/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox is (?:unchecked|not checked)$/')]
+    #[Then('/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" should (?:be unchecked|not be checked)$/')]
+    #[Then('/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" is (?:unchecked|not checked)$/')]
     public function assertCheckboxNotChecked($checkbox)
     {
         $this->assertSession()->checkboxNotChecked($this->fixStepArgument($checkbox));
@@ -498,9 +465,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Prints current URL to console.
      * Example: Then print current URL
      * Example: And print current URL
-     *
-     * @Then /^print current URL$/
      */
+    #[Then('/^print current URL$/')]
     public function printCurrentUrl()
     {
         echo $this->getSession()->getCurrentUrl();
@@ -510,9 +476,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Prints last response to console
      * Example: Then print last response
      * Example: And print last response
-     *
-     * @Then /^print last response$/
      */
+    #[Then('/^print last response$/')]
     public function printLastResponse()
     {
         echo (
@@ -525,9 +490,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      * Opens last response content in browser
      * Example: Then show last response
      * Example: And show last response
-     *
-     * @Then /^show last response$/
      */
+    #[Then('/^show last response$/')]
     public function showLastResponse()
     {
         if (null === $this->getMinkParameter('show_cmd')) {


### PR DESCRIPTION
This switches to using attributes in `MinkContext` as suggested in #46.

This change makes sense only after bumping PHP version requirements as suggested in #47.