### PR TITLE
Allow Behat 4 for Symfony 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "homepage": "https://github.com/FriendsOfBehat/MinkExtension#readme",
     "require": {
         "php": "^8.3",
-        "behat/behat": "^3.31",
+        "behat/behat": "^3.31 || ^4.0",
         "behat/mink": "^1.5",
         "symfony/config": "^7.4 || ^8.0"
     },


### PR DESCRIPTION
## Summary

- Allow Behat 4 alongside the existing Behat 3.31 support in `composer.json`
- Keep Symfony 7.4/8.0 compatibility constraints unchanged
- Unblock Symfony 8 consumers, where Behat 3 cannot resolve because it only supports Symfony components up to 7.x

## Validation

Run locally with PHP 8.5:

- `php8.5 /home/veyra/bin/composer validate --strict`
- `php8.5 vendor/bin/phpspec run -f progress`
- `php8.5 vendor/bin/phpstan analyse --no-progress`
- `php8.5 vendor/bin/php-cs-fixer fix --dry-run --diff --verbose`

Result:

- 12 specs / 47 examples passed
- PHPStan passed
- PHP CS Fixer found no changes

## Notes

This is the companion change needed by `friends-of-behat/symfony-extension` to support Symfony 8 projects with Behat 4.

Prepared with help from Veyra, Badr HAKKARI's Hermes agent.
