### PR TITLE
maint: Support Behat 4.0

### DIFF
--- a/.github/workflows/lock-behat-version.sh
+++ b/.github/workflows/lock-behat-version.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-jq --indent 4 --arg version "$VERSION" '.require |= with_entries(.key as $k | if ($k == "behat/behat") then .value = $version else . end)' < composer.json > composer.json.tmp && mv composer.json.tmp composer.json

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,7 +58,7 @@ jobs:
               run: VERSION=${{ matrix.symfony-version }} .github/workflows/lock-symfony-version.sh
 
             - name: Install dependencies
-              run: composer install --prefer-dist --no-progress --with behat/behat:"${{ matrix.behat-version }}"
+              run: composer update --prefer-dist --no-progress --with behat/behat:"${{ matrix.behat-version }}"
 
             - name: CS Fixer
               run: vendor/bin/php-cs-fixer fix --dry-run

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,18 +26,18 @@ jobs:
                     - '8.0.*'
                     - '8.1.*'
                 behat-version:
-                    - stable
-                    - 4.x-dev
+                    - '3.*'
+                    - '4.*'
                 exclude:
                     # Symfony 8.x requires PHP >= 8.4
                     - php-version: '8.3'
                       symfony-version: '8.0.*'
                     - php-version: '8.3'
                       symfony-version: '8.1.*'
-                    # Behat 3.31 (stable) cannot install with Symfony 8.x
-                    - behat-version: stable
+                    # Behat 3.x cannot install with Symfony 8.x
+                    - behat-version: '3.*'
                       symfony-version: '8.0.*'
-                    - behat-version: stable
+                    - behat-version: '3.*'
                       symfony-version: '8.1.*'
         steps:
             - name: Checkout
@@ -57,15 +57,8 @@ jobs:
             - name: Lock Symfony version
               run: VERSION=${{ matrix.symfony-version }} .github/workflows/lock-symfony-version.sh
 
-            - name: Require behat 4.x
-              if: matrix.behat-version == '4.x-dev'
-              run: |
-                  VERSION="4.x-dev as 3.31.0" .github/workflows/lock-behat-version.sh
-                  composer config minimum-stability dev
-                  composer config prefer-stable true
-
             - name: Install dependencies
-              run: composer install --prefer-dist --no-progress
+              run: composer install --prefer-dist --no-progress --with behat/behat:"${{ matrix.behat-version }}"
 
             - name: CS Fixer
               run: vendor/bin/php-cs-fixer fix --dry-run

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,5 +22,5 @@ Support for the following drivers has been deprecated, since the underlying driv
 The corresponding `Factory` classes will trigger a deprecation notice when they are used to build the driver, for example
 by using `goutte` as the driver identifier in the `behat.yml` configuration file (https://github.com/FriendsOfBehat/MinkExtension/pull/39/).
 
-Note, however, that Behat currently does not have a built-in mechanism to collect such deprecation notices and display
-them in a user-friendly way.
+These deprecations will be reported if running Behat with the `--print-behat-deprecations` option,
+and will cause the build to fail if running with the `--fail-on-behat-deprecations` option. These options can also be set on the `TesterOptions` in a behat config file.

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "homepage": "https://github.com/FriendsOfBehat/MinkExtension#readme",
     "require": {
         "php": "^8.3",
-        "behat/behat": "^3.31",
+        "behat/behat": "^3.31 || ^4.0@alpha",
         "behat/mink": "^1.5",
         "symfony/config": "^7.4 || ^8.0"
     },
@@ -55,5 +55,6 @@
             "vendor/bin/phpspec run -f pretty",
             "vendor/bin/behat --config behat.dist.php -fprogress --strict"
         ]
-    }
+    },
+    "minimum-stability": "stable"
 }

--- a/doc/index.md
+++ b/doc/index.md
@@ -22,7 +22,7 @@ and it provides:
 
 This extension requires:
 
-* Behat 3.0+
+* Behat 3.31+ or 4.0+
 * Mink 1.4+
 
 ### Through Composer
@@ -35,18 +35,32 @@ The easiest way to keep your suite updated is to use [Composer](http://getcompos
     $ composer require --dev behat/mink-extension
     ```
 
-2. Activate the extension by specifying its class in your `behat.yml`:
+2. Activate the extension by specifying its class in your `behat.php`:
 
-    ```yaml
-    # behat.yml
-    default:
-      # ...
-      extensions:
-        Behat\MinkExtension:
-          base_url:  'http://example.com'
-          sessions:
-            default:
-              goutte: ~
+    ```php
+    # behat.php
+    
+    use Behat\Config\Config;
+    use Behat\Config\Extension;
+    use Behat\Config\Profile;
+    use Behat\Config\Suite;
+    use Behat\MinkExtension\ServiceContainer\MinkExtension;
+
+    return (new Config())
+        ->withProfile(
+            (new Profile('default'))
+                //... suite configuration
+                ->withExtension(
+                    new Extension(MinkExtension::class, [
+                        'base_url' => 'http://example.com/',
+                        'sessions' => [
+                            'default' => [
+                                'browserkit_http' => null,
+                            ],
+                        ],
+                    ])
+                )
+        );
     ```
 
 ## Usage
@@ -94,13 +108,26 @@ After installing the extension, there are 4 usage options available:
    Exactly like the previous option, but gives you the ability to keep your main context
    class clean.
 
-    ```yaml
-    default:
-      suites:
-        my_suite:
-          contexts:
-            - FeatureContext
-            - Behat\MinkExtension\Context\MinkContext
+    ```php
+    
+    use Behat\Config\Config;
+    use Behat\Config\Extension;
+    use Behat\Config\Profile;
+    use Behat\Config\Suite;
+    use Behat\MinkExtension\Context\MinkContext::class;
+
+    return (new Config())
+        ->withProfile(
+            (new Profile('default'))
+                ->withSuite(
+                    (new Suite('default'))
+                        ->withContexts(
+                            \FeatureContext::class,
+                            MinkContext::class
+                        )
+                )
+                // ... extension config as above
+        );
     ```
 
     > [!NOTE]
@@ -114,7 +141,7 @@ There are common things between these methods. In each of those, the target cont
 `setMink(Mink $mink)` and `setMinkParameters(array $parameters)` methods. Those methods would
 be automatically called *immediately after* each context creation before each scenario. And
 this `$mink` instance will be preconfigured based on the settings you've provided in your
-`behat.yml`.
+`behat.php`.
 
 ## Configuration
 
@@ -126,17 +153,35 @@ the ability to configure Mink inside Behat to fulfil all your needs.
 You can register as many Mink sessions as you want. For each session, you
 will need to choose the driver you want to use.
 
-```yaml
-default:
-    extensions:
-        Behat\MinkExtension:
-            sessions:
-                first_session:
-                    selenium2: ~
-                second_session:
-                    goutte: ~
-                third_session:
-                    selenium2: ~
+```php
+# behat.php
+
+use Behat\Config\Config;
+use Behat\Config\Extension;
+use Behat\Config\Profile;
+use Behat\MinkExtension\ServiceContainer\MinkExtension;
+
+return (new Config())
+    ->withProfile(
+        (new Profile('default'))
+            //... suite configuration
+            ->withExtension(
+                new Extension(MinkExtension::class, [
+                    'base_url' => 'http://example.com/',
+                    'sessions' => [
+                        'first_session' => [
+                            'selenium2' => null,
+                        ],
+                        'second_session' => [
+                            'browserkit_http' => null,
+                        ],
+                        'third_session' => [
+                            'selenium2' => null,
+                        ]
+                    ],
+                ])
+            )
+    );
 ```
 
 MinkExtension will set the default Mink session for each scenario based on
@@ -150,12 +195,26 @@ and on scenario tags:
 The default session and the default `javascript` session can also be configured for
 each suite:
 
-```yaml
-default:
-    suites:
-        first:
-            mink_session: foo
-            mink_javascript_session: sahi
+ ```php
+    
+use Behat\Config\Config;
+use Behat\Config\Profile;
+use Behat\Config\Suite;
+
+return (new Config())
+    ->withProfile(
+        (new Profile('default'))
+            ->withSuite(
+                (new Suite(
+                    'first',
+                    [
+                        'mink_session'=> 'foo',
+                        'mink_javascript_session' => 'sahi',
+                    ]
+                )
+            )
+            // ... extension config as above, defining a `foo` and `sahi` session
+    );
 ```
 
 If it is not configured explicitly, the `javascript` session is set to the first
@@ -172,21 +231,37 @@ First of all, there are drivers enabling configuration. MinkExtension comes
 with support for 7 drivers out of the box:
 
 * `GoutteDriver` - headless driver without JavaScript support. In order to use
-  it, modify your `behat.yml` profile:
+  it, modify your `behat.php` profile:
 
     > [!IMPORTANT]
     > Support for this driver has been deprecated, since the driver package has been abandoned.
     > It will be removed in the next major version of this extension.
 
-    ```yaml
-    default:
-        extensions:
-            Behat\MinkExtension:
-                sessions:
-                    my_session:
-                        goutte: ~
-    ```
+    ```php
+    # behat.php
 
+    use Behat\Config\Config;
+    use Behat\Config\Extension;
+    use Behat\Config\Profile;
+    use Behat\MinkExtension\ServiceContainer\MinkExtension;
+
+    return (new Config())
+        ->withProfile(
+            (new Profile('default'))
+                //... suite configuration
+                ->withExtension(
+                    new Extension(MinkExtension::class, [
+                        'base_url' => 'http://example.com/',
+                        'sessions' => [
+                            'my_session' => [
+                                'goutte' => null,
+                            ],
+                        ],
+                    ])
+                )
+        );
+    ```
+    
   **Tips: HTTPS and self-signed certificate**
 
   If you use Behat/Mink/Goutte to test your application, and want to test an
@@ -195,116 +270,255 @@ with support for 7 drivers out of the box:
 
   * For `Guzzle 4` or later:
 
-      ```yaml
-      default:
-          extensions:
-              Behat\MinkExtension:
-                  sessions:
-                      my_session:
-                          goutte:
-                              guzzle_parameters:
-                                  verify: false
-      ```
+    ```php
+    # behat.php
+
+    use Behat\Config\Config;
+    use Behat\Config\Extension;
+    use Behat\Config\Profile;
+    use Behat\MinkExtension\ServiceContainer\MinkExtension;
+
+    return (new Config())
+        ->withProfile(
+            (new Profile('default'))
+                //... suite configuration
+                ->withExtension(
+                    new Extension(MinkExtension::class, [
+                        'base_url' => 'http://example.com/',
+                        'sessions' => [
+                            'my_session' => [
+                                'goutte' => [
+                                    'guzzle_parameters' => [
+                                        'verify' => false,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ])
+                )
+        );
+    ```
 
   * For `Guzzle 3` or earlier:
 
-      ```yaml
-      default:
-          extensions:
-              Behat\MinkExtension:
-                  sessions:
-                      my_session:
-                          goutte:
-                              guzzle_parameters:
-                                  ssl.certificate_authority: false
-      ```
+    ```php
+    # behat.php
+
+    use Behat\Config\Config;
+    use Behat\Config\Extension;
+    use Behat\Config\Profile;
+    use Behat\MinkExtension\ServiceContainer\MinkExtension;
+
+    return (new Config())
+        ->withProfile(
+            (new Profile('default'))
+                //... suite configuration
+                ->withExtension(
+                    new Extension(MinkExtension::class, [
+                        'base_url' => 'http://example.com/',
+                        'sessions' => [
+                            'my_session' => [
+                                'goutte' => [
+                                    'guzzle_parameters' => [
+                                        'ssl.certificate_authority' => false,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ])
+                )
+        );
+    ```
+
 
 * `Selenium2Driver` - javascript driver. In order to use it, modify your
-  `behat.yml` profile:
+  `behat.php` profile:
 
-    ```yaml
-    default:
-        extensions:
-            Behat\MinkExtension:
-                sessions:
-                    my_session:
-                        selenium2: ~
+    ```php
+    # behat.php
+
+    use Behat\Config\Config;
+    use Behat\Config\Extension;
+    use Behat\Config\Profile;
+    use Behat\MinkExtension\ServiceContainer\MinkExtension;
+
+    return (new Config())
+        ->withProfile(
+            (new Profile('default'))
+                //... suite configuration
+                ->withExtension(
+                    new Extension(MinkExtension::class, [
+                        'base_url' => 'http://example.com/',
+                        'sessions' => [
+                            'my_session' => [
+                                'selenium2' => null,
+                            ],
+                        ],
+                    ])
+                )
+        );
     ```
 
 * `SauceLabsDriver` - special flavor of the Selenium2Driver configured to use the
   selenium2 hosted installation of saucelabs.com. In order to use it, modify your
-  `behat.yml` profile:
+  `behat.php` profile:
 
-    ```yaml
-    default:
-        extensions:
-            Behat\MinkExtension:
-                sessions:
-                    my_session:
-                        sauce_labs: ~
+    
+    ```php
+    # behat.php
+
+    use Behat\Config\Config;
+    use Behat\Config\Extension;
+    use Behat\Config\Profile;
+    use Behat\MinkExtension\ServiceContainer\MinkExtension;
+
+    return (new Config())
+        ->withProfile(
+            (new Profile('default'))
+                //... suite configuration
+                ->withExtension(
+                    new Extension(MinkExtension::class, [
+                        'base_url' => 'http://example.com/',
+                        'sessions' => [
+                            'my_session' => [
+                                'sauce_labs' => null,
+                            ],
+                        ],
+                    ])
+                )
+        );
     ```
-
+    
 * `BrowserStackDriver` - special flavor of the Selenium2Driver configured to use the
   selenium2 hosted installation of browserstack.com. In order to use it, modify your
-  `behat.yml` profile:
+  `behat.php` profile:
 
-    ```yaml
-    default:
-        extensions:
-            Behat\MinkExtension:
-                sessions:
-                    my_session:
-                        browser_stack: ~
+    
+    ```php
+    # behat.php
+
+    use Behat\Config\Config;
+    use Behat\Config\Extension;
+    use Behat\Config\Profile;
+    use Behat\MinkExtension\ServiceContainer\MinkExtension;
+
+    return (new Config())
+        ->withProfile(
+            (new Profile('default'))
+                //... suite configuration
+                ->withExtension(
+                    new Extension(MinkExtension::class, [
+                        'base_url' => 'http://example.com/',
+                        'sessions' => [
+                            'my_session' => [
+                                'browser_stack' => null,
+                            ],
+                        ],
+                    ])
+                )
+        );
     ```
 
-* `SeleniumDriver` - javascript driver. In order to use it, modify your `behat.yml`
+* `SeleniumDriver` - javascript driver. In order to use it, modify your `behat.php`
   profile:
 
     > [!IMPORTANT]
     > Support for this driver has been deprecated, since the driver package has been abandoned.
     > It will be removed in the next major version of this extension.
 
-    ```yaml
-    default:
-        extensions:
-            Behat\MinkExtension:
-                sessions:
-                    my_session:
-                        selenium: ~
+
+    ```php
+    # behat.php
+
+    use Behat\Config\Config;
+    use Behat\Config\Extension;
+    use Behat\Config\Profile;
+    use Behat\MinkExtension\ServiceContainer\MinkExtension;
+
+    return (new Config())
+        ->withProfile(
+            (new Profile('default'))
+                //... suite configuration
+                ->withExtension(
+                    new Extension(MinkExtension::class, [
+                        'base_url' => 'http://example.com/',
+                        'sessions' => [
+                            'my_session' => [
+                                'selenium' => null,
+                            ],
+                        ],
+                    ])
+                )
+        );
     ```
 
-* `SahiDriver` - javascript driver. In order to use it, modify your `behat.yml`
+* `SahiDriver` - javascript driver. In order to use it, modify your `behat.php`
   profile:
 
     > [!IMPORTANT]
     > Support for this driver has been deprecated, since the driver package has been abandoned.
     > It will be removed in the next major version of this extension.
 
-    ```yaml
-    default:
-        extensions:
-            Behat\MinkExtension:
-                sessions:
-                    my_session:
-                        sahi: ~
+
+    ```php
+    # behat.php
+
+    use Behat\Config\Config;
+    use Behat\Config\Extension;
+    use Behat\Config\Profile;
+    use Behat\MinkExtension\ServiceContainer\MinkExtension;
+
+    return (new Config())
+        ->withProfile(
+            (new Profile('default'))
+                //... suite configuration
+                ->withExtension(
+                    new Extension(MinkExtension::class, [
+                        'base_url' => 'http://example.com/',
+                        'sessions' => [
+                            'my_session' => [
+                                'sahi' => null,
+                            ],
+                        ],
+                    ])
+                )
+        );
     ```
 
 * `ZombieDriver` - zombie.js javascript headless driver. In order to use it, modify
-  your `behat.yml` profile:
+  your `behat.php` profile:
 
     > [!IMPORTANT]
     > Support for this driver has been deprecated, since the driver package has been abandoned.
     > It will be removed in the next major version of this extension.
 
-    ```yaml
-    default:
-        extensions:
-            Behat\MinkExtension:
-                sessions:
-                    default:
-                        zombie:
-                            # Specify the path to the node_modules directory.
-                            node_modules_path: /usr/local/lib/node_modules/
+
+    ```php
+    # behat.php
+
+    use Behat\Config\Config;
+    use Behat\Config\Extension;
+    use Behat\Config\Profile;
+    use Behat\MinkExtension\ServiceContainer\MinkExtension;
+
+    return (new Config())
+        ->withProfile(
+            (new Profile('default'))
+                //... suite configuration
+                ->withExtension(
+                    new Extension(MinkExtension::class, [
+                        'base_url' => 'http://example.com/',
+                        'sessions' => [
+                            'my_session' => [
+                                'zombie' => [
+                                    // Specify the path to the node_modules directory.
+                                    'node_modules_path': '/usr/local/lib/node_modules/',
+                                ],
+                            ],
+                        ],
+                    ])
+                )
+        );
     ```
 
 > [!NOTE]

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/SahiFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/SahiFactory.php
@@ -44,7 +44,7 @@ class SahiFactory implements DriverFactory
      */
     public function buildDriver(array $config): Definition
     {
-        DeprecationCollector::trigger('Configuration for the "sahi" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of MinkExtension.');
+        DeprecationCollector::trigger('Since friends-of-behat/mink-extension 2.8.0: Configuration for the "sahi" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of MinkExtension.');
 
         if (!class_exists('Behat\Mink\Driver\SahiDriver')) {
             throw new \RuntimeException('Install MinkSahiDriver in order to use sahi driver.');

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/SahiFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/SahiFactory.php
@@ -10,6 +10,7 @@
 
 namespace Behat\MinkExtension\ServiceContainer\Driver;
 
+use Behat\Testwork\Deprecation\DeprecationCollector;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -43,7 +44,7 @@ class SahiFactory implements DriverFactory
      */
     public function buildDriver(array $config): Definition
     {
-        trigger_deprecation('friends-of-behat/mink-extension', '2.8.0', 'Configuration for the "sahi" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of this extension.');
+        DeprecationCollector::trigger('Configuration for the "sahi" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of MinkExtension.');
 
         if (!class_exists('Behat\Mink\Driver\SahiDriver')) {
             throw new \RuntimeException('Install MinkSahiDriver in order to use sahi driver.');

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/SeleniumFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/SeleniumFactory.php
@@ -42,7 +42,7 @@ class SeleniumFactory implements DriverFactory
      */
     public function buildDriver(array $config): Definition
     {
-        DeprecationCollector::trigger('Configuration for the "selenium" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of MinkExtension.');
+        DeprecationCollector::trigger('Since friends-of-behat/mink-extension 2.8.0: Configuration for the "selenium" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of MinkExtension.');
 
         if (!class_exists('Behat\Mink\Driver\SeleniumDriver')) {
             throw new \RuntimeException('Install MinkSeleniumDriver in order to activate selenium session.');

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/SeleniumFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/SeleniumFactory.php
@@ -10,6 +10,7 @@
 
 namespace Behat\MinkExtension\ServiceContainer\Driver;
 
+use Behat\Testwork\Deprecation\DeprecationCollector;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -41,7 +42,7 @@ class SeleniumFactory implements DriverFactory
      */
     public function buildDriver(array $config): Definition
     {
-        trigger_deprecation('friends-of-behat/mink-extension', '2.8.0', 'Configuration for the "selenium" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of this extension.');
+        DeprecationCollector::trigger('Configuration for the "selenium" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of MinkExtension.');
 
         if (!class_exists('Behat\Mink\Driver\SeleniumDriver')) {
             throw new \RuntimeException('Install MinkSeleniumDriver in order to activate selenium session.');

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/ZombieFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/ZombieFactory.php
@@ -10,6 +10,7 @@
 
 namespace Behat\MinkExtension\ServiceContainer\Driver;
 
+use Behat\Testwork\Deprecation\DeprecationCollector;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -44,7 +45,7 @@ class ZombieFactory implements DriverFactory
      */
     public function buildDriver(array $config): Definition
     {
-        trigger_deprecation('friends-of-behat/mink-extension', '2.8.0', 'Configuration for the "zombie" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of this extension.');
+        DeprecationCollector::trigger('Configuration for the "zombie" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of MinkExtension.');
 
         if (!class_exists('Behat\Mink\Driver\ZombieDriver')) {
             throw new \RuntimeException('Install MinkZombieDriver in order to use zombie driver.');

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/ZombieFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/ZombieFactory.php
@@ -45,7 +45,7 @@ class ZombieFactory implements DriverFactory
      */
     public function buildDriver(array $config): Definition
     {
-        DeprecationCollector::trigger('Configuration for the "zombie" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of MinkExtension.');
+        DeprecationCollector::trigger('Since friends-of-behat/mink-extension 2.8.0: Configuration for the "zombie" driver is deprecated, since the client implementation has been abandoned. Support for it will be removed in the next major version of MinkExtension.');
 
         if (!class_exists('Behat\Mink\Driver\ZombieDriver')) {
             throw new \RuntimeException('Install MinkZombieDriver in order to use zombie driver.');


### PR DESCRIPTION
Now that Behat 4.0.0-alpha1 has been release, add official support for Behat 4.0. 

Also updates deprecations to use the official deprecation mechanism for Behat extensions, and updates docs to show how to configure the extension using Behat's PHP config (which is required from 4.0 onwards).