### PR TITLE
Clean up driver documentation and tighten behat/mink constraint

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,6 +9,7 @@ This document summarizes the changes relevant for users when upgrading to new ve
 - PHP `^7.4 || ^8` → `^8.3`
 - `symfony/config` `^4.4 || ^5.0 || ^6.0 || ^7.0` → `^7.4 || ^8.0`
 - `behat/behat` `^3.0.5` → `^3.32 || ^4.0`
+- `behat/mink` `^1.5` → `^1.11`
 
 ## Abandoned driver factories removed
 
@@ -21,6 +22,9 @@ Switch to `browserkit_http` (via `behat/mink-browserkit-driver`) or another acti
 
 Step definitions in `MinkContext` now use PHP 8 attributes (`#[\Behat\Step\Given(...)]` etc.) instead of
 docblock annotations. Behat 3.32+ and Behat 4.x are both supported.
+
+Behat 4 introduces PHP-based configuration files (`behat.php`) alongside the classic `behat.yml`. The
+documentation examples now use the `behat.php` format; existing `behat.yml` configurations continue to work.
 
 ## `FailureShowListener`, `SessionsListener` and `MinkExtension` are now `final`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,6 +22,12 @@ Switch to `browserkit_http` (via `behat/mink-browserkit-driver`) or another acti
 Step definitions in `MinkContext` now use PHP 8 attributes (`#[\Behat\Step\Given(...)]` etc.) instead of
 docblock annotations. Behat 3.32+ and Behat 4.x are both supported.
 
+## `FailureShowListener`, `SessionsListener` and `MinkExtension` are now `final`
+
+These classes were marked as soft `@final` in 2.8.0 and are now actually `final`.
+You can no longer extend them. If you relied on inheritance, use composition instead
+(wrap or decorate them, or register your own service).
+
 # Upgrade to 2.8
 
 ## Soft `@final` and `@internal` declarations added

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,7 +8,7 @@ This document summarizes the changes relevant for users when upgrading to new ve
 
 - PHP `^7.4 || ^8` → `^8.3`
 - `symfony/config` `^4.4 || ^5.0 || ^6.0 || ^7.0` → `^7.4 || ^8.0`
-- `behat/behat` `^3.0.5` → `^3.31`
+- `behat/behat` `^3.0.5` → `^3.32 || ^4.0`
 
 ## Abandoned driver factories removed
 
@@ -20,7 +20,7 @@ Switch to `browserkit_http` (via `behat/mink-browserkit-driver`) or another acti
 ## Behat 4 compatibility
 
 Step definitions in `MinkContext` now use PHP 8 attributes (`#[\Behat\Step\Given(...)]` etc.) instead of
-docblock annotations. Behat 3.31+ and Behat 4.x are both supported.
+docblock annotations. Behat 3.32+ and Behat 4.x are both supported.
 
 # Upgrade to 2.8
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^8.3",
         "behat/behat": "^3.32 || ^4.0",
-        "behat/mink": "^1.5",
+        "behat/mink": "^1.11",
         "symfony/config": "^7.4 || ^8.0"
     },
     "require-dev": {

--- a/doc/index.md
+++ b/doc/index.md
@@ -209,11 +209,11 @@ return (new Config())
                     'first',
                     [
                         'mink_session'=> 'foo',
-                        'mink_javascript_session' => 'sahi',
+                        'mink_javascript_session' => 'selenium2',
                     ]
                 )
             )
-            // ... extension config as above, defining a `foo` and `sahi` session
+            // ... extension config as above, defining a `foo` and `selenium2` session
     );
 ```
 
@@ -222,20 +222,18 @@ session using a javascript driver in the order of the configuration (it would
 be `first_session` in the example above as `selenium2` supports Javascript).
 If it is not configured explicitly, the default session is set to the first
 session using a non-javascript driver if any, or to the first javascript session
-otherwise (it would be `second_session` above as `goutte` does not support
-javascript).
+otherwise (it would be `second_session` above as `browserkit_http` does not
+support javascript).
 
 ### Drivers
 
 First of all, there are drivers enabling configuration. MinkExtension comes
-with support for 7 drivers out of the box:
+with support for the following drivers out of the box:
 
-* `GoutteDriver` - headless driver without JavaScript support. In order to use
-  it, modify your `behat.php` profile:
-
-    > [!IMPORTANT]
-    > Support for this driver has been deprecated, since the driver package has been abandoned.
-    > It will be removed in the next major version of this extension.
+* `browserkit_http` - headless driver without JavaScript support, based on
+  Symfony's BrowserKit and HttpClient components. It is the recommended
+  replacement for the removed Goutte driver. In order to use it, install
+  `behat/mink-browserkit-driver` and modify your `behat.php` profile:
 
     ```php
     # behat.php
@@ -254,21 +252,19 @@ with support for 7 drivers out of the box:
                         'base_url' => 'http://example.com/',
                         'sessions' => [
                             'my_session' => [
-                                'goutte' => null,
+                                'browserkit_http' => null,
                             ],
                         ],
                     ])
                 )
         );
     ```
-    
+
   **Tips: HTTPS and self-signed certificate**
 
-  If you use Behat/Mink/Goutte to test your application, and want to test an
-  application secured with HTTPS, but with a self-signed certificate, you can use
-  the following parameters to avoid the validation error triggered by Guzzle:
-
-  * For `Guzzle 4` or later:
+  If you want to test an application secured with HTTPS but using a self-signed
+  certificate, you can disable certificate verification through the underlying
+  Symfony HttpClient via `http_client_parameters`:
 
     ```php
     # behat.php
@@ -287,9 +283,10 @@ with support for 7 drivers out of the box:
                         'base_url' => 'http://example.com/',
                         'sessions' => [
                             'my_session' => [
-                                'goutte' => [
-                                    'guzzle_parameters' => [
-                                        'verify' => false,
+                                'browserkit_http' => [
+                                    'http_client_parameters' => [
+                                        'verify_peer' => false,
+                                        'verify_host' => false,
                                     ],
                                 ],
                             ],
@@ -298,38 +295,6 @@ with support for 7 drivers out of the box:
                 )
         );
     ```
-
-  * For `Guzzle 3` or earlier:
-
-    ```php
-    # behat.php
-
-    use Behat\Config\Config;
-    use Behat\Config\Extension;
-    use Behat\Config\Profile;
-    use Behat\MinkExtension\ServiceContainer\MinkExtension;
-
-    return (new Config())
-        ->withProfile(
-            (new Profile('default'))
-                //... suite configuration
-                ->withExtension(
-                    new Extension(MinkExtension::class, [
-                        'base_url' => 'http://example.com/',
-                        'sessions' => [
-                            'my_session' => [
-                                'goutte' => [
-                                    'guzzle_parameters' => [
-                                        'ssl.certificate_authority' => false,
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ])
-                )
-        );
-    ```
-
 
 * `Selenium2Driver` - javascript driver. In order to use it, modify your
   `behat.php` profile:
@@ -352,6 +317,37 @@ with support for 7 drivers out of the box:
                         'sessions' => [
                             'my_session' => [
                                 'selenium2' => null,
+                            ],
+                        ],
+                    ])
+                )
+        );
+    ```
+
+* `Selenium4Driver` - javascript driver for Selenium 4 / W3C WebDriver. Its basic
+  usage is analogous to `selenium2` (it also accepts `browser` and `wd_host`), but
+  it exposes an extra `name` option and expects W3C-style `capabilities` structured
+  under `alwaysMatch` / `firstMatch` (e.g. `goog:chromeOptions`). In order to use it,
+  modify your `behat.php` profile:
+
+    ```php
+    # behat.php
+
+    use Behat\Config\Config;
+    use Behat\Config\Extension;
+    use Behat\Config\Profile;
+    use Behat\MinkExtension\ServiceContainer\MinkExtension;
+
+    return (new Config())
+        ->withProfile(
+            (new Profile('default'))
+                //... suite configuration
+                ->withExtension(
+                    new Extension(MinkExtension::class, [
+                        'base_url' => 'http://example.com/',
+                        'sessions' => [
+                            'my_session' => [
+                                'selenium4' => null,
                             ],
                         ],
                     ])
@@ -419,119 +415,12 @@ with support for 7 drivers out of the box:
         );
     ```
 
-* `SeleniumDriver` - javascript driver. In order to use it, modify your `behat.php`
-  profile:
+If you're using Composer, you need to install the drivers that you need first:
 
-    > [!IMPORTANT]
-    > Support for this driver has been deprecated, since the driver package has been abandoned.
-    > It will be removed in the next major version of this extension.
-
-
-    ```php
-    # behat.php
-
-    use Behat\Config\Config;
-    use Behat\Config\Extension;
-    use Behat\Config\Profile;
-    use Behat\MinkExtension\ServiceContainer\MinkExtension;
-
-    return (new Config())
-        ->withProfile(
-            (new Profile('default'))
-                //... suite configuration
-                ->withExtension(
-                    new Extension(MinkExtension::class, [
-                        'base_url' => 'http://example.com/',
-                        'sessions' => [
-                            'my_session' => [
-                                'selenium' => null,
-                            ],
-                        ],
-                    ])
-                )
-        );
-    ```
-
-* `SahiDriver` - javascript driver. In order to use it, modify your `behat.php`
-  profile:
-
-    > [!IMPORTANT]
-    > Support for this driver has been deprecated, since the driver package has been abandoned.
-    > It will be removed in the next major version of this extension.
-
-
-    ```php
-    # behat.php
-
-    use Behat\Config\Config;
-    use Behat\Config\Extension;
-    use Behat\Config\Profile;
-    use Behat\MinkExtension\ServiceContainer\MinkExtension;
-
-    return (new Config())
-        ->withProfile(
-            (new Profile('default'))
-                //... suite configuration
-                ->withExtension(
-                    new Extension(MinkExtension::class, [
-                        'base_url' => 'http://example.com/',
-                        'sessions' => [
-                            'my_session' => [
-                                'sahi' => null,
-                            ],
-                        ],
-                    ])
-                )
-        );
-    ```
-
-* `ZombieDriver` - zombie.js javascript headless driver. In order to use it, modify
-  your `behat.php` profile:
-
-    > [!IMPORTANT]
-    > Support for this driver has been deprecated, since the driver package has been abandoned.
-    > It will be removed in the next major version of this extension.
-
-
-    ```php
-    # behat.php
-
-    use Behat\Config\Config;
-    use Behat\Config\Extension;
-    use Behat\Config\Profile;
-    use Behat\MinkExtension\ServiceContainer\MinkExtension;
-
-    return (new Config())
-        ->withProfile(
-            (new Profile('default'))
-                //... suite configuration
-                ->withExtension(
-                    new Extension(MinkExtension::class, [
-                        'base_url' => 'http://example.com/',
-                        'sessions' => [
-                            'my_session' => [
-                                'zombie' => [
-                                    // Specify the path to the node_modules directory.
-                                    'node_modules_path': '/usr/local/lib/node_modules/',
-                                ],
-                            ],
-                        ],
-                    ])
-                )
-        );
-    ```
-
-> [!NOTE]
-> The phar version of Mink comes bundled with all 5 drivers and you don't need to do
-> anything except enabling them in order to use them.
-
-But if you're using Composer, you need to install drivers that you need first:
-
-- GoutteDriver - `behat/mink-goutte-driver`
-- SeleniumDriver - `behat/mink-selenium-driver`
-- Selenium2Driver (also used for SauceLabs and BrowserStack) - `behat/mink-selenium2-driver`
-- SahiDriver - `behat/mink-sahi-driver`
-- ZombieDriver - `behat/mink-zombie-driver`
+- `browserkit_http` - `behat/mink-browserkit-driver` (also requires `symfony/browser-kit` and `symfony/http-client`)
+- `selenium2` (also used for SauceLabs, BrowserStack and Appium) - `behat/mink-selenium2-driver`
+- `selenium4` - `ediasoft/mink-selenium4-driver`
+- `webdriver_classic` - `mink/webdriver-classic-driver`
 
 > [!NOTE]
 > All drivers share the same API, which means that you could use multiple drivers
@@ -557,8 +446,8 @@ There's other useful parameters, that you can use to configure your suite:
   to the system temp dir)
 * `show_auto` - Whether the opened page should be shown automatically when
   a step fails.
-* `browser_name` - meta-option, that defines which browser to use for Sahi,
-  Selenium and Selenium2 drivers.
+* `browser_name` - meta-option, that defines which browser to use for the
+  Selenium2 and Selenium4 drivers.
 * `default_session` - defines the default session (driver) to be used for all
   untagged scenarios. This could be any enabled session name.
 * `javascript_session` - defines the javascript session (driver) (the one, which

--- a/doc/index.md
+++ b/doc/index.md
@@ -8,7 +8,7 @@ and languages provide functional testing tools. Today we'll talk about how to
 use Behat for functional testing of web applications. [Mink](http://mink.behat.org)
 is a tool exactly for that and this extension provides integration for it.
 
-Basically, MinkExtension is an integration layer between Behat 3.32+ and Mink 1.4+
+Basically, MinkExtension is an integration layer between Behat 3.32+ and Mink 1.11+
 and it provides:
 
 * Additional services for Behat (`Mink`, `Sessions`, `Drivers`).
@@ -23,7 +23,7 @@ and it provides:
 This extension requires:
 
 * Behat 3.32+ or 4.0+
-* Mink 1.4+
+* Mink 1.11+
 
 ### Through Composer
 

--- a/src/Behat/MinkExtension/Listener/FailureShowListener.php
+++ b/src/Behat/MinkExtension/Listener/FailureShowListener.php
@@ -23,11 +23,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
- * @final since 2.8.0
- *
  * @internal since 2.8.0
  */
-class FailureShowListener implements EventSubscriberInterface
+final class FailureShowListener implements EventSubscriberInterface
 {
     private Mink $mink;
 

--- a/src/Behat/MinkExtension/Listener/FailureShowListener.php
+++ b/src/Behat/MinkExtension/Listener/FailureShowListener.php
@@ -23,7 +23,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
- * @internal since 2.8.0
+ * @internal
  */
 final class FailureShowListener implements EventSubscriberInterface
 {

--- a/src/Behat/MinkExtension/Listener/SessionsListener.php
+++ b/src/Behat/MinkExtension/Listener/SessionsListener.php
@@ -26,7 +26,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
- * @internal since 2.8.0
+ * @internal
  */
 final class SessionsListener implements EventSubscriberInterface
 {

--- a/src/Behat/MinkExtension/Listener/SessionsListener.php
+++ b/src/Behat/MinkExtension/Listener/SessionsListener.php
@@ -26,11 +26,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
- * @final since 2.8.0
- *
  * @internal since 2.8.0
  */
-class SessionsListener implements EventSubscriberInterface
+final class SessionsListener implements EventSubscriberInterface
 {
     private Mink $mink;
     private string $defaultSession;

--- a/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php
+++ b/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php
@@ -34,10 +34,8 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  * @author Christophe Coevoet <stof@notk.org>
- *
- * @final since 2.8.0
  */
-class MinkExtension implements ExtensionInterface
+final class MinkExtension implements ExtensionInterface
 {
     public const MINK_ID = 'mink';
     public const SELECTORS_HANDLER_ID = 'mink.selectors_handler';


### PR DESCRIPTION
Final touches before the 3.0 release:

- **Make `FailureShowListener`, `SessionsListener` and `MinkExtension` `final`**: fulfils the soft `@final` promise made in 2.8.0; these classes can no longer be extended (use composition instead). Documented in `UPGRADING.md`.
- **Remove abandoned drivers from the docs & document `browserkit_http`**: drops the Goutte/Selenium/Sahi/Zombie driver docs and documents the maintained `browserkit_http` driver in `doc/index.md`.
- **Require `behat/mink ^1.11`**: bumps the minimum Mink version.