### PR TITLE
Fix double-escaped quote regex in translation catalogs

### DIFF
--- a/features/search.fr.feature
+++ b/features/search.fr.feature
@@ -1,0 +1,17 @@
+# language: fr
+Fonctionnalité: Recherche
+  Afin de voir la définition d'un mot
+  En tant qu'utilisateur du site
+  Je dois pouvoir rechercher un mot
+
+  Scénario: Recherche d'une page qui existe
+    Etant donné que je suis sur "/wiki/Main_Page"
+    Quand je remplis "search" avec "Behavior Driven Development"
+    Et je presse "Search"
+    Alors je devrais voir "agile software development"
+
+  Scénario: Recherche d'une page qui n'existe pas
+    Etant donné que je suis sur "/wiki/Main_Page"
+    Quand je remplis "search" avec "Glory Driven Development"
+    Et je presse "Search"
+    Alors je devrais voir "Search results"

--- a/i18n/cs.xliff
+++ b/i18n/cs.xliff
@@ -23,92 +23,92 @@
             <target><![CDATA[/^(?:|pře)jdu o jednu stránku vpřed$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^stisknu(?:| tlačítko) "(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^stisknu(?:| tlačítko) "(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^kliknu na(?:| odkaz) "(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^kliknu na(?:| odkaz) "(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^zadám do "(?P<field>(?:[^"]|\\")*)" hodnotu "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^zadám do "(?P<field>(?:[^"]|\")*)" hodnotu "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^zadám "(?P<value>(?:[^"]|\\")*)" do "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^zadám "(?P<value>(?:[^"]|\")*)" do "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^vyplním formulář:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^vyberu "(?P<option>(?:[^"]|\\")*)" z "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^vyberu "(?P<option>(?:[^"]|\")*)" z "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^ještě vyberu "(?P<option>(?:[^"]|\\")*)" z "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^ještě vyberu "(?P<option>(?:[^"]|\")*)" z "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:zaškrtnu|označím) "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:zaškrtnu|označím) "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^odznačím "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^odznačím "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^nahraji soubor "(?P<path>[^"]*)" do "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^nahraji soubor "(?P<path>[^"]*)" do "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^musím vidět(?:| text) "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^musím vidět(?:| text) "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^stránka musí obsahovat "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^stránka musí obsahovat "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^nesmím vidět(?:| text) "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^nesmím vidět(?:| text) "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^stránka nesmí obsahovat "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^stránka nesmí obsahovat "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^pole "(?P<field>(?:[^"]|\\")*)" musí obsahovat "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^pole "(?P<field>(?:[^"]|\")*)" musí obsahovat "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^pole "(?P<field>(?:[^"]|\\")*)" nesmí obsahovat "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^pole "(?P<field>(?:[^"]|\")*)" nesmí obsahovat "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^pole "(?P<checkbox>(?:[^"]|\\")*)" musí být (?:zaškrtnuto|vybráno|označeno)$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^pole "(?P<checkbox>(?:[^"]|\")*)" musí být (?:zaškrtnuto|vybráno|označeno)$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^pole "(?P<checkbox>(?:[^"]|\\")*)" nesmí být (?:zaškrtnuto|vybráno|označeno)$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^pole "(?P<checkbox>(?:[^"]|\")*)" nesmí být (?:zaškrtnuto|vybráno|označeno)$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
             <target><![CDATA[/^musím být na stránce "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:url|adresa|url adresa) musí mít tvar (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:url|adresa|url adresa) musí mít tvar (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^element "(?P<element>[^"]*)" musí obsahovat "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^element "(?P<element>[^"]*)" musí obsahovat "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^musím vidět(?:| text) "(?P<text>(?:[^"]|\\")*)" uvnitř elementu "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^musím vidět(?:| text) "(?P<text>(?:[^"]|\")*)" uvnitř elementu "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/da.xliff
+++ b/i18n/da.xliff
@@ -31,101 +31,101 @@
             <target><![CDATA[/^(?:|jeg )går en side frem$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jeg )trykker "(?P<knap>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jeg )trykker "(?P<knap>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jeg )følger "(?P<link>(?:[^"]|\\")*)"$/]]></target>
-            <target><![CDATA[/^(?:|jeg )klikker "(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jeg )følger "(?P<link>(?:[^"]|\")*)"$/]]></target>
+            <target><![CDATA[/^(?:|jeg )klikker "(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jeg )udfylder "(?P<felt>(?:[^"]|\\")*)" med "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jeg )udfylder "(?P<felt>(?:[^"]|\")*)" med "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with:$/]]></source>
-            <target><![CDATA[/^(?:|jeg )udfylder "(?P<felt>(?:[^"]|\\")*)" med:$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with:$/]]></source>
+            <target><![CDATA[/^(?:|jeg )udfylder "(?P<felt>(?:[^"]|\")*)" med:$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jeg )udfylder "(?P<value>(?:[^"]|\\")*)" for "(?P<felt>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jeg )udfylder "(?P<value>(?:[^"]|\")*)" for "(?P<felt>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|jeg )udfylder følgende:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jeg )vælger "(?P<valgmulighed>(?:[^"]|\\")*)" fra "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jeg )vælger "(?P<valgmulighed>(?:[^"]|\")*)" fra "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jeg )derudover vælger "(?P<valgmulighed>(?:[^"]|\\")*)" fra "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jeg )derudover vælger "(?P<valgmulighed>(?:[^"]|\")*)" fra "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jeg )markerer "(?P<valgmulighed>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jeg )markerer "(?P<valgmulighed>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jeg )afmarkerer "(?P<valgmulighed>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jeg )afmarkerer "(?P<valgmulighed>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jeg )vedhæfter filen "(?P<sti>[^"]*)" til "(?P<felt>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jeg )vedhæfter filen "(?P<sti>[^"]*)" til "(?P<felt>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|skulle jeg )se "(?P<tekst>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|skulle jeg )se "(?P<tekst>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|skulle jeg )se tekst matche (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|skulle jeg )se tekst matche (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|skulle jeg )ikke se tekst matche (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|skulle jeg )ikke se tekst matche (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^skulle responsen indeholde "(?P<tekst>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^skulle responsen indeholde "(?P<tekst>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|skulle jeg )ikke se "(?P<tekst>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|skulle jeg )ikke se "(?P<tekst>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^skulle responsen ikke indeholde "(?P<tekst>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^skulle responsen ikke indeholde "(?P<tekst>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^skulle feltet "(?P<felt>(?:[^"]|\\")*)" indeholde "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^skulle feltet "(?P<felt>(?:[^"]|\")*)" indeholde "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^skulle feltet "(?P<felt>(?:[^"]|\\")*)" ikke indeholde "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^skulle feltet "(?P<felt>(?:[^"]|\")*)" ikke indeholde "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^skulle afkrydsningsfeltet "(?P<felt>(?:[^"]|\\")*)" være markeret$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^skulle afkrydsningsfeltet "(?P<felt>(?:[^"]|\")*)" være markeret$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-is-checked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" (?:is|should be) checked$/]]></source>
-            <target><![CDATA[/^er afkrydsningsfeltet "(?P<felt>(?:[^"]|\\")*)" markeret$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" (?:is|should be) checked$/]]></source>
+            <target><![CDATA[/^er afkrydsningsfeltet "(?P<felt>(?:[^"]|\")*)" markeret$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" should (?:be unchecked|not be checked)$/]]></source>
-            <target><![CDATA[/^skulle afkrydsningsfeltet "(?P<checkbox>(?:[^"]|\\")*)" være afmarkeret$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" should (?:be unchecked|not be checked)$/]]></source>
+            <target><![CDATA[/^skulle afkrydsningsfeltet "(?P<checkbox>(?:[^"]|\")*)" være afmarkeret$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-is-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" is (?:unchecked|not checked)$/]]></source>
-            <target><![CDATA[/^er afkrydsningsfeltet "(?P<felt>(?:[^"]|\\")*)" afmarkeret$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" is (?:unchecked|not checked)$/]]></source>
+            <target><![CDATA[/^er afkrydsningsfeltet "(?P<felt>(?:[^"]|\")*)" afmarkeret$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^skulle afkrydsningsfeltet "(?P<felt>(?:[^"]|\\")*)" ikke være markeret$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^skulle afkrydsningsfeltet "(?P<felt>(?:[^"]|\")*)" ikke være markeret$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
@@ -136,24 +136,24 @@
             <target><![CDATA[/^(?:|skulle jeg )være på hjemmesiden$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^skulle webadressen matche (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^skulle webadressen matche (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^skulle elementet "(?P<element>[^"]*)" indeholde "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^skulle elementet "(?P<element>[^"]*)" indeholde "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-not-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^skulle elementet "(?P<element>[^"]*)" ikke indeholde "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^skulle elementet "(?P<element>[^"]*)" ikke indeholde "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|skulle jeg )se "(?P<tekst>(?:[^"]|\\")*)" i elementet "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|skulle jeg )se "(?P<tekst>(?:[^"]|\")*)" i elementet "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|skulle jeg )ikke se "(?P<tekst>(?:[^"]|\\")*)" i elementet "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|skulle jeg )ikke se "(?P<tekst>(?:[^"]|\")*)" i elementet "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/de.xliff
+++ b/i18n/de.xliff
@@ -31,52 +31,52 @@
             <target><![CDATA[/^(?:|ich )gehe (?:|ich )eine Seite vorwärts$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ich )drücke (?:|ich )"(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ich )drücke (?:|ich )"(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ich )folge (?:|ich )"(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ich )folge (?:|ich )"(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ich )gebe (?:|ich )in das Feld "(?P<field>(?:[^"]|\\")*)" "(?P<value>(?:[^"]|\\")*)" ein$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ich )gebe (?:|ich )in das Feld "(?P<field>(?:[^"]|\")*)" "(?P<value>(?:[^"]|\")*)" ein$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ich )gebe (?:|ich )"(?P<value>(?:[^"]|\\")*)" in "(?P<field>(?:[^"]|\\")*)" ein$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ich )gebe (?:|ich )"(?P<value>(?:[^"]|\")*)" in "(?P<field>(?:[^"]|\")*)" ein$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|ich )gebe (?:|ich )das folgende ein:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ich )wähle (?:|ich )"(?P<option>(?:[^"]|\\")*)" von "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ich )wähle (?:|ich )"(?P<option>(?:[^"]|\")*)" von "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ich )wähle (?:|ich )zusätzlich "(?P<option>(?:[^"]|\\")*)" von "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ich )wähle (?:|ich )zusätzlich "(?P<option>(?:[^"]|\")*)" von "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ich )aktiviere (?:|ich )"(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ich )aktiviere (?:|ich )"(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ich )deaktiviere (?:|ich )"(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ich )deaktiviere (?:|ich )"(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ich )lade (?:|ich )die Datei "(?P<path>[^"]*)" in "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ich )lade (?:|ich )die Datei "(?P<path>[^"]*)" in "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
             <target><![CDATA[/^(?:|ich )sollte (?:|ich )auf "(?P<page>[^"]+)" sein$/]]></target>
         </trans-unit>
        <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|sollte )die Webadresse (?:|sollte )mit (?P<pattern>"(?:[^"]|\\")*") übereinstimmen$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|sollte )die Webadresse (?:|sollte )mit (?P<pattern>"(?:[^"]|\")*") übereinstimmen$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-status-code-should-be">
             <source><![CDATA[/^the response status code should be (?P<code>\d+)$/]]></source>
@@ -87,44 +87,44 @@
             <target><![CDATA[/^(?:|sollte )die Status-Code-Rückmeldung (?:|sollte )nicht (?P<code>\d+) sein$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ich )sollte (?:|ich )"(?P<text>(?:[^"]|\\")*)" sehen$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ich )sollte (?:|ich )"(?P<text>(?:[^"]|\")*)" sehen$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ich )sollte (?:|ich )nicht "(?P<text>(?:[^"]|\\")*)" sehen$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ich )sollte (?:|ich )nicht "(?P<text>(?:[^"]|\")*)" sehen$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|ich )sollte (?:|ich )folgenden Text sehen (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|ich )sollte (?:|ich )folgenden Text sehen (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|ich )sollte (?:|ich )nicht folgenden Text sehen (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|ich )sollte (?:|ich )nicht folgenden Text sehen (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|sollte )die Rückmeldung (?:|sollte )"(?P<text>(?:[^"]|\\")*)" enthalten$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|sollte )die Rückmeldung (?:|sollte )"(?P<text>(?:[^"]|\")*)" enthalten$/]]></target>
         </trans-unit>
        <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|sollte )die Rückmeldung (?:|sollte )nicht "(?P<text>(?:[^"]|\\")*)" enthalten$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|sollte )die Rückmeldung (?:|sollte )nicht "(?P<text>(?:[^"]|\")*)" enthalten$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|ich )sollte (?:|ich )"(?P<text>(?:[^"]|\\")*)" im "(?P<element>[^"]*)" Element sehen$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|ich )sollte (?:|ich )"(?P<text>(?:[^"]|\")*)" im "(?P<element>[^"]*)" Element sehen$/]]></target>
         </trans-unit>
          <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|ich )sollte (?:|ich )nicht "(?P<text>(?:[^"]|\\")*)" im "(?P<element>[^"]*)" Element sehen$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|ich )sollte (?:|ich )nicht "(?P<text>(?:[^"]|\")*)" im "(?P<element>[^"]*)" Element sehen$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|sollte )das "(?P<element>[^"]*)" Element (?:|sollte )"(?P<value>(?:[^"]|\\")*)" enthalten$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|sollte )das "(?P<element>[^"]*)" Element (?:|sollte )"(?P<value>(?:[^"]|\")*)" enthalten$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-not-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|sollte )das "(?P<element>[^"]*)" Element (?:|sollte )nicht "(?P<value>(?:[^"]|\\")*)" enthalten$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|sollte )das "(?P<element>[^"]*)" Element (?:|sollte )nicht "(?P<value>(?:[^"]|\")*)" enthalten$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>
@@ -135,20 +135,20 @@
             <target><![CDATA[/^(?:|ich )sollte (?:|ich )kein "(?P<element>[^"]*)" Element sehen$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|sollte )das "(?P<field>(?:[^"]|\\")*)" Feld (?:|sollte )"(?P<value>(?:[^"]|\\")*)" enthalten$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|sollte )das "(?P<field>(?:[^"]|\")*)" Feld (?:|sollte )"(?P<value>(?:[^"]|\")*)" enthalten$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|sollte )das "(?P<field>(?:[^"]|\\")*)" Feld (?:|sollte )nicht "(?P<value>(?:[^"]|\\")*)" enthalten$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|sollte )das "(?P<field>(?:[^"]|\")*)" Feld (?:|sollte )nicht "(?P<value>(?:[^"]|\")*)" enthalten$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^(?:|sollte )die "(?P<checkbox>(?:[^"]|\\")*)" checkbox (?:|sollte )aktiviert sein$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^(?:|sollte )die "(?P<checkbox>(?:[^"]|\")*)" checkbox (?:|sollte )aktiviert sein$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^(?:|sollte )die "(?P<checkbox>(?:[^"]|\\")*)" checkbox (?:|sollte )nicht aktiviert sein$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^(?:|sollte )die "(?P<checkbox>(?:[^"]|\")*)" checkbox (?:|sollte )nicht aktiviert sein$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-num-elements">
             <source><![CDATA[/^(?:|I )should see (?P<num>\d+) "(?P<element>[^"]*)" elements?$/]]></source>

--- a/i18n/es.xliff
+++ b/i18n/es.xliff
@@ -31,104 +31,104 @@
             <target><![CDATA[/^voy hacia adelante una página$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^presiono "(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^presiono "(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^sigo "(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^sigo "(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^relleno "(?P<field>(?:[^"]|\\")*)" con "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^relleno "(?P<field>(?:[^"]|\")*)" con "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^relleno con "(?P<value>(?:[^"]|\\")*)" a "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^relleno con "(?P<value>(?:[^"]|\")*)" a "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^relleno lo siguiente:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^selecciono "(?P<option>(?:[^"]|\\")*)" de "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^selecciono "(?P<option>(?:[^"]|\")*)" de "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^adicionalmente selecciono "(?P<option>(?:[^"]|\\")*)" de "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^adicionalmente selecciono "(?P<option>(?:[^"]|\")*)" de "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^marco "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^marco "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^desmarco "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^desmarco "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^adjunto el archivo "(?P<path>[^"]*)" a "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^adjunto el archivo "(?P<path>[^"]*)" a "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^debo ver "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^debo ver "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^no debo ver "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^no debo ver "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^debo ver texto que siga el patrón (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^debo ver texto que siga el patrón (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^no debo ver texto que siga el patrón (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^no debo ver texto que siga el patrón (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^la respuesta debe contener "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^la respuesta debe contener "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^la respuesta no debe contener "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^la respuesta no debe contener "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^el campo "(?P<field>(?:[^"]|\\")*)" debe contener "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^el campo "(?P<field>(?:[^"]|\")*)" debe contener "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^el campo "(?P<field>(?:[^"]|\\")*)" no debe contener "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^el campo "(?P<field>(?:[^"]|\")*)" no debe contener "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
             <target><![CDATA[/^la casilla de selección "(?P<checkbox>[^"]*)" debe estar marcada$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^la casilla de selección "(?P<checkbox>(?:[^"]|\\")*)" no debe estar marcada$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^la casilla de selección "(?P<checkbox>(?:[^"]|\")*)" no debe estar marcada$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
             <target><![CDATA[/^debo estar en "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^la URL debe seguir el patrón (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^la URL debe seguir el patrón (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^el elemento "(?P<element>[^"]*)" debe contener "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^el elemento "(?P<element>[^"]*)" debe contener "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^debo ver "(?P<text>(?:[^"]|\\")*)" en el elemento "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^debo ver "(?P<text>(?:[^"]|\")*)" en el elemento "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^no debo ver "(?P<text>(?:[^"]|\\")*)" en el elemento "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^no debo ver "(?P<text>(?:[^"]|\")*)" en el elemento "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/fr.xliff
+++ b/i18n/fr.xliff
@@ -31,84 +31,84 @@
             <target><![CDATA[/^(?:|j')avance d'une page$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|je )presse "(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|je )presse "(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|je )suis "(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|je )suis "(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|je )remplis "(?P<field>(?:[^"]|\\")*)" avec "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|je )remplis "(?P<field>(?:[^"]|\")*)" avec "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|je )remplis "(?P<value>(?:[^"]|\\")*)" pour "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|je )remplis "(?P<value>(?:[^"]|\")*)" pour "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|je )remplis le texte suivant:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|je )sélectionne "(?P<option>(?:[^"]|\\")*)" depuis "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|je )sélectionne "(?P<option>(?:[^"]|\")*)" depuis "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|je )sélectionne une autre option "(?P<option>(?:[^"]|\\")*)" depuis "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|je )sélectionne une autre option "(?P<option>(?:[^"]|\")*)" depuis "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|je )coche "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|je )coche "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|je )décoche "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|je )décoche "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|j')attache le fichier "(?P<path>[^"]*)" à "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|j')attache le fichier "(?P<path>[^"]*)" à "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|je )devrais voir "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|je )devrais voir "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|je )devrais voir un texte suivant le motif (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|je )devrais voir un texte suivant le motif (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|je )ne devrais pas voir de texte suivant le motif (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|je )ne devrais pas voir de texte suivant le motif (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^la réponse devrait contenir "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^la réponse devrait contenir "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|je )ne devrais pas voir "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|je )ne devrais pas voir "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^la réponse ne devrait pas contenir "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^la réponse ne devrait pas contenir "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^le champ "(?P<field>(?:[^"]|\\")*)" devrait contenir "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^le champ "(?P<field>(?:[^"]|\")*)" devrait contenir "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^le champ "(?P<field>(?:[^"]|\\")*)" ne devrait pas contenir "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^le champ "(?P<field>(?:[^"]|\")*)" ne devrait pas contenir "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
             <target><![CDATA[/^la case à cocher "(?P<checkbox>[^"]*)" devrait être cochée$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^la case à cocher "(?P<checkbox>(?:[^"]|\\")*)" ne devrait pas être cochée$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^la case à cocher "(?P<checkbox>(?:[^"]|\")*)" ne devrait pas être cochée$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
@@ -119,24 +119,24 @@
             <target><![CDATA[/^(?:|je )devrais être sur la page d'accueil$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^l'(?i)url(?-i) devrait suivre le motif (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^l'(?i)url(?-i) devrait suivre le motif (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^l'élément "(?P<element>[^"]*)" devrait contenir "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^l'élément "(?P<element>[^"]*)" devrait contenir "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-not-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^l'élément "(?P<element>[^"]*)" ne devrait pas contenir "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^l'élément "(?P<element>[^"]*)" ne devrait pas contenir "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|je )devrais voir "(?P<text>(?:[^"]|\\")*)" dans l'élément "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|je )devrais voir "(?P<text>(?:[^"]|\")*)" dans l'élément "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|je )ne devrais pas voir "(?P<text>(?:[^"]|\\")*)" dans l'élément "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|je )ne devrais pas voir "(?P<text>(?:[^"]|\")*)" dans l'élément "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/hu.xliff
+++ b/i18n/hu.xliff
@@ -31,96 +31,96 @@
             <target><![CDATA[/^a következő oldalra (látogatok|látogat)$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(megnyomom|megnyomja|lenyomom|lenyomja) az? "(?P<button>(?:[^"]|\\")*)" gombot$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(megnyomom|megnyomja|lenyomom|lenyomja) az? "(?P<button>(?:[^"]|\")*)" gombot$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(követem|követi) az? "(?P<link>(?:[^"]|\\")*)" linket$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(követem|követi) az? "(?P<link>(?:[^"]|\")*)" linket$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(kitöltöm|kitölti) az? "(?P<field>(?:[^"]|\\")*)" mezőt "(?P<value>(?:[^"]|\\")*)" értékkel$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(kitöltöm|kitölti) az? "(?P<field>(?:[^"]|\")*)" mezőt "(?P<value>(?:[^"]|\")*)" értékkel$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with:$/]]></source>
-            <target><![CDATA[/^(kitöltöm|kitölti) az? "(?P<field>(?:[^"]|\\")*)" mezőt a következő értékekkel:$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with:$/]]></source>
+            <target><![CDATA[/^(kitöltöm|kitölti) az? "(?P<field>(?:[^"]|\")*)" mezőt a következő értékekkel:$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^az? "(?P<value>(?:[^"]|\\")*)" értékkel (kitöltöm|kitölti) az? "(?P<field>(?:[^"]|\\")*)" mezőt$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^az? "(?P<value>(?:[^"]|\")*)" értékkel (kitöltöm|kitölti) az? "(?P<field>(?:[^"]|\")*)" mezőt$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^Amennyiben (kitöltöm|kitölti) a következőket:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(kiválasztom|kiválasztja) az? "(?P<option>(?:[^"]|\\")*)" leheőséget az? "(?P<select>(?:[^"]|\\")*)" legördülő listából$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(kiválasztom|kiválasztja) az? "(?P<option>(?:[^"]|\")*)" leheőséget az? "(?P<select>(?:[^"]|\")*)" legördülő listából$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(kiválasztom|kiválasztja) a "(?P<option>(?:[^"]|\\")*)" további lehetőséget az? "(?P<select>(?:[^"]|\\")*)" legördülő listából$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(kiválasztom|kiválasztja) a "(?P<option>(?:[^"]|\")*)" további lehetőséget az? "(?P<select>(?:[^"]|\")*)" legördülő listából$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(kiválasztom|kiválasztja) az? "(?P<option>(?:[^"]|\\")*) opciót"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(kiválasztom|kiválasztja) az? "(?P<option>(?:[^"]|\")*) opciót"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(törlöm|törli) az? "(?P<option>(?:[^"]|\\")*)" opciót$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(törlöm|törli) az? "(?P<option>(?:[^"]|\")*)" opciót$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(csatolom|csatolja) az? "(?P<path>[^"]*)" fájlt az? "(?P<field>(?:[^"]|\\")*)" mezőhöz$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(csatolom|csatolja) az? "(?P<path>[^"]*)" fájlt az? "(?P<field>(?:[^"]|\")*)" mezőhöz$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^az? "(?P<text>(?:[^"]|\\")*)" szöveget kell (látnom|látnia)$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^az? "(?P<text>(?:[^"]|\")*)" szöveget kell (látnom|látnia)$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^az? (?P<pattern>"(?:[^"]|\\")*") mintára illeszkedő szöveget (látnom|látnia) kell$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^az? (?P<pattern>"(?:[^"]|\")*") mintára illeszkedő szöveget (látnom|látnia) kell$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^az? (?P<pattern>"(?:[^"]|\\")*") mintára illeszkedő szöveget nem szabad (látnom|látnia)$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^az? (?P<pattern>"(?:[^"]|\")*") mintára illeszkedő szöveget nem szabad (látnom|látnia)$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^a válasznak tartalmaznia kell a következőt: "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^a válasznak tartalmaznia kell a következőt: "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^az? "(?P<text>(?:[^"]|\\")*)" szöveget nem szabad (látnom|látnia)$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^az? "(?P<text>(?:[^"]|\")*)" szöveget nem szabad (látnom|látnia)$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^a válasznak nem szabad tartalmaznia "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^a válasznak nem szabad tartalmaznia "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^az? "(?P<field>(?:[^"]|\\")*)" mezőnek tartalmaznia kell a következő értéket: "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^az? "(?P<field>(?:[^"]|\")*)" mezőnek tartalmaznia kell a következő értéket: "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^az? "(?P<field>(?:[^"]|\\")*)" mezőnek nem szabad tartalmaznia a következő értéket: "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^az? "(?P<field>(?:[^"]|\")*)" mezőnek nem szabad tartalmaznia a következő értéket: "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^az? "(?P<checkbox>(?:[^"]|\\")*)" jelölőnégyzetnek be kell jelölve lennie$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^az? "(?P<checkbox>(?:[^"]|\")*)" jelölőnégyzetnek be kell jelölve lennie$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-is-checked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" (?:is|should be) checked$/]]></source>
-            <target><![CDATA[/^az? "(?P<checkbox>(?:[^"]|\\")*)" jelölőnégyzetnek be kell lennie jelölve$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" (?:is|should be) checked$/]]></source>
+            <target><![CDATA[/^az? "(?P<checkbox>(?:[^"]|\")*)" jelölőnégyzetnek be kell lennie jelölve$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" should (?:be unchecked|not be checked)$/]]></source>
-            <target><![CDATA[/^az? "(?P<checkbox>(?:[^"]|\\")*)" jelölőnégyzetnek törölve kell lennie$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" should (?:be unchecked|not be checked)$/]]></source>
+            <target><![CDATA[/^az? "(?P<checkbox>(?:[^"]|\")*)" jelölőnégyzetnek törölve kell lennie$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-is-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" is (?:unchecked|not checked)$/]]></source>
-            <target><![CDATA[/^az? "(?P<checkbox>(?:[^"]|\\")*)" jelölőnégyzet törölve van$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" is (?:unchecked|not checked)$/]]></source>
+            <target><![CDATA[/^az? "(?P<checkbox>(?:[^"]|\")*)" jelölőnégyzet törölve van$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
@@ -131,24 +131,24 @@
             <target><![CDATA[/^a címlapon kell (lennem|lennie)/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"([^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^az? (url|webcím) illeszkedik a következő mintára: (?P<pattern>"([^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"([^"]|\")*")$/]]></source>
+            <target><![CDATA[/^az? (url|webcím) illeszkedik a következő mintára: (?P<pattern>"([^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^az? "(?P<element>[^"]*)" tartalmaznia kell a következő értéket: "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^az? "(?P<element>[^"]*)" tartalmaznia kell a következő értéket: "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-not-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^az? "(?P<element>[^"]*)" nem szabad tartalmaznia a következő értéket: "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^az? "(?P<element>[^"]*)" nem szabad tartalmaznia a következő értéket: "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^az? "(?P<text>(?:[^"]|\\")*)" szöveget (látnom|látnia) kell az? "(?P<element>[^"]*)" elemben$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^az? "(?P<text>(?:[^"]|\")*)" szöveget (látnom|látnia) kell az? "(?P<element>[^"]*)" elemben$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^az? "(?P<text>(?:[^"]|\\")*)" szöveget nem szabad (látnom|látnia) az? "(?P<element>[^"]*)" elemben$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^az? "(?P<text>(?:[^"]|\")*)" szöveget nem szabad (látnom|látnia) az? "(?P<element>[^"]*)" elemben$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/id.xliff
+++ b/i18n/id.xliff
@@ -31,96 +31,96 @@
             <target><![CDATA[/^(?:|saya )maju satu halaman$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|saya )menekan (?:|tombol )"(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|saya )menekan (?:|tombol )"(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|saya )mengikuti (?:|tautan )"(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|saya )mengikuti (?:|tautan )"(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-           <target><![CDATA[/^(?:|saya )mengisi (?:|isian )"(?P<field>(?:[^"]|\\")*)" dengan (?:|nilai )"(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+           <target><![CDATA[/^(?:|saya )mengisi (?:|isian )"(?P<field>(?:[^"]|\")*)" dengan (?:|nilai )"(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with:$/]]></source>
-            <target><![CDATA[/^(?:|saya )mengisi (?:|isian )"(?P<field>(?:[^"]|\\")*)" dengan (?:|nilai ):$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with:$/]]></source>
+            <target><![CDATA[/^(?:|saya )mengisi (?:|isian )"(?P<field>(?:[^"]|\")*)" dengan (?:|nilai ):$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|saya )mengisi (?:|nilai )"(?P<value>(?:[^"]|\\")*)" untuk (?:|isian )"(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|saya )mengisi (?:|nilai )"(?P<value>(?:[^"]|\")*)" untuk (?:|isian )"(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|saya )mengisi:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|saya )memilih (?:|opsi )"(?P<option>(?:[^"]|\\")*)" pada (?:|pilihan )"(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|saya )memilih (?:|opsi )"(?P<option>(?:[^"]|\")*)" pada (?:|pilihan )"(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|saya )menambahkan pilihan "(?P<option>(?:[^"]|\\")*)" pada (?:|pilihan )"(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|saya )menambahkan pilihan "(?P<option>(?:[^"]|\")*)" pada (?:|pilihan )"(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|saya )menandai (?:|opsi )"(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|saya )menandai (?:|opsi )"(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|saya )tidak menandai (?:|opsi )"(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|saya )tidak menandai (?:|opsi )"(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|saya )melampirkan file "(?P<path>[^"]*)" untuk (?:|isian )"(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|saya )melampirkan file "(?P<path>[^"]*)" untuk (?:|isian )"(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|saya )harus melihat (?:|teks |pesan )"(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|saya )harus melihat (?:|teks |pesan )"(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|saya )harus melihat teks yang cocok dengan (?:|pola )(?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|saya )harus melihat teks yang cocok dengan (?:|pola )(?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|saya )tidak melihat teks yang cocok dengan (?:|pola )(?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|saya )tidak melihat teks yang cocok dengan (?:|pola )(?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^respon harus memiliki (?:|teks )"(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^respon harus memiliki (?:|teks )"(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|saya )tidak melihat (?:|teks )"(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|saya )tidak melihat (?:|teks )"(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^respon tidak memiliki (?:|teks )"(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^respon tidak memiliki (?:|teks )"(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^isian "(?P<field>(?:[^"]|\\")*)" harus memiliki nilai "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^isian "(?P<field>(?:[^"]|\")*)" harus memiliki nilai "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^isian "(?P<field>(?:[^"]|\\")*)" tidak memiliki nilai "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^isian "(?P<field>(?:[^"]|\")*)" tidak memiliki nilai "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^pilihan "(?P<checkbox>(?:[^"]|\\")*)" dicentang$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^pilihan "(?P<checkbox>(?:[^"]|\")*)" dicentang$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-is-checked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" (?:is|should be) checked$/]]></source>
-            <target><![CDATA[/^pilihan "(?P<checkbox>(?:[^"]|\\")*)" (?:harus|seharusnya) dicentang$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" (?:is|should be) checked$/]]></source>
+            <target><![CDATA[/^pilihan "(?P<checkbox>(?:[^"]|\")*)" (?:harus|seharusnya) dicentang$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" should (?:be unchecked|not be checked)$/]]></source>
-            <target><![CDATA[/^pilihan "(?P<checkbox>(?:[^"]|\\")*)" tidak (?:harus|seharusnya) dicentang$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" should (?:be unchecked|not be checked)$/]]></source>
+            <target><![CDATA[/^pilihan "(?P<checkbox>(?:[^"]|\")*)" tidak (?:harus|seharusnya) dicentang$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-is-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" is (?:unchecked|not checked)$/]]></source>
-            <target><![CDATA[/^pilihan "(?P<checkbox>(?:[^"]|\\")*)" (?:seharusnya |harus )tidak dicentang$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" is (?:unchecked|not checked)$/]]></source>
+            <target><![CDATA[/^pilihan "(?P<checkbox>(?:[^"]|\")*)" (?:seharusnya |harus )tidak dicentang$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
@@ -131,24 +131,24 @@
             <target><![CDATA[/^(?:|saya )harus (?:|berada )di (?:|halaman )beranda$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^url (?i)url(?-i) harus cocok dengan (?:|pola )(?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^url (?i)url(?-i) harus cocok dengan (?:|pola )(?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^elemen "(?P<element>[^"]*)" harus memiliki nilai "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^elemen "(?P<element>[^"]*)" harus memiliki nilai "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-not-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^elemen "(?P<element>[^"]*)" tidak memiliki nilai "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^elemen "(?P<element>[^"]*)" tidak memiliki nilai "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|saya )harus melihat (?:|teks )"(?P<text>(?:[^"]|\\")*)" pada elemen "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|saya )harus melihat (?:|teks )"(?P<text>(?:[^"]|\")*)" pada elemen "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|saya )tidak melihat (?:|teks )"(?P<text>(?:[^"]|\\")*)" pada elemen "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|saya )tidak melihat (?:|teks )"(?P<text>(?:[^"]|\")*)" pada elemen "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/it.xliff
+++ b/i18n/it.xliff
@@ -23,100 +23,100 @@
             <target><![CDATA[/^(?:|io )avanzo di una pagina$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|io )premo "(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|io )premo "(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|io )clicco sul link "(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|io )clicco sul link "(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|io )compilo il campo "(?P<field>(?:[^"]|\\")*)" con "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|io )compilo il campo "(?P<field>(?:[^"]|\")*)" con "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|io )inserisco il valore "(?P<value>(?:[^"]|\\")*)" per il campo "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|io )inserisco il valore "(?P<value>(?:[^"]|\")*)" per il campo "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|io )compilo con:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|io )seleziono "(?P<option>(?:[^"]|\\")*)" da "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|io )seleziono "(?P<option>(?:[^"]|\")*)" da "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|io )seleziono anche "(?P<option>(?:[^"]|\\")*)" da "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|io )seleziono anche "(?P<option>(?:[^"]|\")*)" da "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|io )metto la spunta a "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|io )metto la spunta a "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|io )rimuovo la spunta da "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|io )rimuovo la spunta da "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|io )aggiungo il file "(?P<path>[^"]*)" a "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|io )aggiungo il file "(?P<path>[^"]*)" a "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|io )dovrei vedere "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|io )dovrei vedere "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|io )dovrei vedere un testo nel formato (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|io )dovrei vedere un testo nel formato (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|io )non dovrei vedere un testo nel formato (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|io )non dovrei vedere un testo nel formato (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^la risposta dovrebbe contenere "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^la risposta dovrebbe contenere "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|io )non dovrei vedere "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|io )non dovrei vedere "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^la risposta non dovrebbe contenere "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^la risposta non dovrebbe contenere "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^il campo "(?P<field>(?:[^"]|\\")*)" dovrebbe contenere "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^il campo "(?P<field>(?:[^"]|\")*)" dovrebbe contenere "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^il campo "(?P<field>(?:[^"]|\\")*)" non dovrebbe contenere "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^il campo "(?P<field>(?:[^"]|\")*)" non dovrebbe contenere "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
             <target><![CDATA[/^l'opzione "(?P<checkbox>[^"]*)" dovrebbe essere spuntata$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^l'opzione "(?P<checkbox>(?:[^"]|\\")*)" non dovrebbe essere spuntata$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^l'opzione "(?P<checkbox>(?:[^"]|\")*)" non dovrebbe essere spuntata$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
             <target><![CDATA[/^(?:|io )dovrei essere sulla pagina "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^l'(?i)url(?-i) dovrebbe essere (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^l'(?i)url(?-i) dovrebbe essere (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^l'elemento "(?P<element>[^"]*)" dovrebbe contenere "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^l'elemento "(?P<element>[^"]*)" dovrebbe contenere "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|io )dovrei vedere "(?P<text>(?:[^"]|\\")*)" nell'elemento "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|io )dovrei vedere "(?P<text>(?:[^"]|\")*)" nell'elemento "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/ja.xliff
+++ b/i18n/ja.xliff
@@ -31,80 +31,80 @@
             <target><![CDATA[/^(?:|ユーザーが )履歴の次のページヘ進む$/u]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ユーザーが )"(?P<button>(?:[^"]|\\")*)" ボタンをクリックする$/u]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ユーザーが )"(?P<button>(?:[^"]|\")*)" ボタンをクリックする$/u]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ユーザーが )"(?P<link>(?:[^"]|\\")*)" のリンク先へ移動する$/u]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ユーザーが )"(?P<link>(?:[^"]|\")*)" のリンク先へ移動する$/u]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ユーザーが )"(?P<field>(?:[^"]|\\")*)" フィールドに "(?P<value>(?:[^"]|\\")*)" と入力する$/u]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ユーザーが )"(?P<field>(?:[^"]|\")*)" フィールドに "(?P<value>(?:[^"]|\")*)" と入力する$/u]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with:$/]]></source>
-            <target><![CDATA[/^(?:|ユーザーが )"(?P<field>(?:[^"]|\\")*)" フィールドに以下の値を入力する:$/u]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with:$/]]></source>
+            <target><![CDATA[/^(?:|ユーザーが )"(?P<field>(?:[^"]|\")*)" フィールドに以下の値を入力する:$/u]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ユーザーが )"(?P<value>(?:[^"]|\\")*)" という値を "(?P<field>(?:[^"]|\\")*)" に入力する$/u]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ユーザーが )"(?P<value>(?:[^"]|\")*)" という値を "(?P<field>(?:[^"]|\")*)" に入力する$/u]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|ユーザーが)次のように入力する:$/u]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ユーザーが )"(?P<option>(?:[^"]|\\")*)" という値を "(?P<select>(?:[^"]|\\")*)" から選択する$/u]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ユーザーが )"(?P<option>(?:[^"]|\")*)" という値を "(?P<select>(?:[^"]|\")*)" から選択する$/u]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ユーザーが )"(?P<option>(?:[^"]|\\")*)" という値を "(?P<select>(?:[^"]|\\")*)" から追加で選択する$/u]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ユーザーが )"(?P<option>(?:[^"]|\")*)" という値を "(?P<select>(?:[^"]|\")*)" から追加で選択する$/u]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ユーザーが )"(?P<option>(?:[^"]|\\")*)" にチェックをつける$/u]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ユーザーが )"(?P<option>(?:[^"]|\")*)" にチェックをつける$/u]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ユーザーが )"(?P<option>(?:[^"]|\\")*)" のチェックをはずす$/u]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ユーザーが )"(?P<option>(?:[^"]|\")*)" のチェックをはずす$/u]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ユーザーが)パス "(?P<path>[^"]*)" にあるファイルを "(?P<field>(?:[^"]|\\")*)" に添付する$/u]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ユーザーが)パス "(?P<path>[^"]*)" にあるファイルを "(?P<field>(?:[^"]|\")*)" に添付する$/u]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|画面に )"(?P<text>(?:[^"]|\\")*)" と表示されていること$/u]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|画面に )"(?P<text>(?:[^"]|\")*)" と表示されていること$/u]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^レスポンスに "(?P<text>(?:[^"]|\\")*)" が含まれていること$/u]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^レスポンスに "(?P<text>(?:[^"]|\")*)" が含まれていること$/u]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|画面に )"(?P<text>(?:[^"]|\\")*)" と表示されていないこと$/u]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|画面に )"(?P<text>(?:[^"]|\")*)" と表示されていないこと$/u]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^レスポンスに "(?P<text>(?:[^"]|\\")*)" が含まれていないこと$/u]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^レスポンスに "(?P<text>(?:[^"]|\")*)" が含まれていないこと$/u]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^"(?P<field>(?:[^"]|\\")*)" フィールドに "(?P<value>(?:[^"]|\\")*)" が含まれていること$/u]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^"(?P<field>(?:[^"]|\")*)" フィールドに "(?P<value>(?:[^"]|\")*)" が含まれていること$/u]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^"(?P<field>(?:[^"]|\\")*)" フィールドに "(?P<value>(?:[^"]|\\")*)" が含まれていないこと$/u]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^"(?P<field>(?:[^"]|\")*)" フィールドに "(?P<value>(?:[^"]|\")*)" が含まれていないこと$/u]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^チェックボックス "(?P<checkbox>(?:[^"]|\\")*)" のチェックがついていること$/u]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^チェックボックス "(?P<checkbox>(?:[^"]|\")*)" のチェックがついていること$/u]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^チェックボックス "(?P<checkbox>(?:[^"]|\\")*)" のチェックがはずれていること$/u]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^チェックボックス "(?P<checkbox>(?:[^"]|\")*)" のチェックがはずれていること$/u]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
@@ -115,24 +115,24 @@
             <target><![CDATA[/^(?:|ユーザーが )ホームページを表示していること$/u]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?i)url(?-i)が (?P<pattern>"(?:[^"]|\\")*") にマッチすること$/u]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?i)url(?-i)が (?P<pattern>"(?:[^"]|\")*") にマッチすること$/u]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^"(?P<element>[^"]*)" エレメントに "(?P<value>(?:[^"]|\\")*)" という値が含まれていること$/u]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^"(?P<element>[^"]*)" エレメントに "(?P<value>(?:[^"]|\")*)" という値が含まれていること$/u]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-not-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^"(?P<element>[^"]*)" エレメントに "(?P<value>(?:[^"]|\\")*)" という値が含まれていないこと$/u]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^"(?P<element>[^"]*)" エレメントに "(?P<value>(?:[^"]|\")*)" という値が含まれていないこと$/u]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^"(?P<element>[^"]*)" エレメントに "(?P<text>(?:[^"]|\\")*)" と表示されていること$/u]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^"(?P<element>[^"]*)" エレメントに "(?P<text>(?:[^"]|\")*)" と表示されていること$/u]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^"(?P<element>[^"]*)" エレメントに "(?P<text>(?:[^"]|\\")*)" と表示されていないこと$/u]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^"(?P<element>[^"]*)" エレメントに "(?P<text>(?:[^"]|\")*)" と表示されていないこと$/u]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>
@@ -167,12 +167,12 @@
             <target><![CDATA[/^現在のURLを表示$/]]></target>
         </trans-unit>
         <trans-unit id="-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|画面に )"(?P<pattern>"(?:[^"]|\\")*")" にマッチするテキストが表示されていること$/u]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|画面に )"(?P<pattern>"(?:[^"]|\")*")" にマッチするテキストが表示されていること$/u]]></target>
         </trans-unit>
         <trans-unit id="-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|画面に )"(?P<pattern>"(?:[^"]|\\")*")" にマッチするテキストが表示されていないこと$/u]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|画面に )"(?P<pattern>"(?:[^"]|\")*")" にマッチするテキストが表示されていないこと$/u]]></target>
         </trans-unit>
     </body>
   </file>

--- a/i18n/nl.xliff
+++ b/i18n/nl.xliff
@@ -31,100 +31,100 @@
             <target><![CDATA[/^(?:|ik )een pagina vooruit ga$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ik )druk op "(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ik )druk op "(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ik )"(?P<link>(?:[^"]|\\")*)" volg$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ik )"(?P<link>(?:[^"]|\")*)" volg$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ik )het veld "(?P<field>(?:[^"]|\\")*)" invul met "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ik )het veld "(?P<field>(?:[^"]|\")*)" invul met "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with:$/]]></source>
-            <target><![CDATA[/^(?:|ik )het veld "(?P<field>(?:[^"]|\\")*)" invul met:$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with:$/]]></source>
+            <target><![CDATA[/^(?:|ik )het veld "(?P<field>(?:[^"]|\")*)" invul met:$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ik )de waarde "(?P<value>(?:[^"]|\\")*)" invul in "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ik )de waarde "(?P<value>(?:[^"]|\")*)" invul in "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|ik )het volgende invul:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ik )de optie "(?P<option>(?:[^"]|\\")*)" selecteer voor "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ik )de optie "(?P<option>(?:[^"]|\")*)" selecteer voor "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ik )daarnaast de optie "(?P<option>(?:[^"]|\\")*)" selecteer voor "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ik )daarnaast de optie "(?P<option>(?:[^"]|\")*)" selecteer voor "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ik )"(?P<option>(?:[^"]|\\")*)" aanvink$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ik )"(?P<option>(?:[^"]|\")*)" aanvink$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ik )"(?P<option>(?:[^"]|\\")*)" uitvink$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ik )"(?P<option>(?:[^"]|\")*)" uitvink$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|ik )het bestand "(?P<path>[^"]*)" toevoeg aan "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|ik )het bestand "(?P<path>[^"]*)" toevoeg aan "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^moet (?:|ik )"(?P<text>(?:[^"]|\\")*)" zien$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^moet (?:|ik )"(?P<text>(?:[^"]|\")*)" zien$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^moet (?:|ik )de volgende tekst zien (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^moet (?:|ik )de volgende tekst zien (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^moet (?:|ik )de volgende tekst niet zien (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^moet (?:|ik )de volgende tekst niet zien (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^moet het antwoord "(?P<text>(?:[^"]|\\")*)" bevatten$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^moet het antwoord "(?P<text>(?:[^"]|\")*)" bevatten$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^moet (?:|ik )niet "(?P<text>(?:[^"]|\\")*)" zien$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^moet (?:|ik )niet "(?P<text>(?:[^"]|\")*)" zien$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^moet het antwoord "(?P<text>(?:[^"]|\\")*)" niet bevatten$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^moet het antwoord "(?P<text>(?:[^"]|\")*)" niet bevatten$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^moet "(?P<field>(?:[^"]|\\")*)" "(?P<value>(?:[^"]|\\")*)" bevatten$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^moet "(?P<field>(?:[^"]|\")*)" "(?P<value>(?:[^"]|\")*)" bevatten$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^moet "(?P<field>(?:[^"]|\\")*)" "(?P<value>(?:[^"]|\\")*)" niet bevatten$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^moet "(?P<field>(?:[^"]|\")*)" "(?P<value>(?:[^"]|\")*)" niet bevatten$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^moet "(?P<checkbox>(?:[^"]|\\")*)" aangevinkt zijn$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^moet "(?P<checkbox>(?:[^"]|\")*)" aangevinkt zijn$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-is-checked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" (?:is|should be) checked$/]]></source>
-            <target><![CDATA[/^"(?P<checkbox>(?:[^"]|\\")*)" (?:is|zou moeten zijn) aangevinkt$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" (?:is|should be) checked$/]]></source>
+            <target><![CDATA[/^"(?P<checkbox>(?:[^"]|\")*)" (?:is|zou moeten zijn) aangevinkt$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" should (?:be unchecked|not be checked)$/]]></source>
-            <target><![CDATA[/^moet "(?P<checkbox>(?:[^"]|\\")*)" niet aangevinkt zijn$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" should (?:be unchecked|not be checked)$/]]></source>
+            <target><![CDATA[/^moet "(?P<checkbox>(?:[^"]|\")*)" niet aangevinkt zijn$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^moet "(?P<checkbox>(?:[^"]|\\")*)" niet aangevinkt zijn$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^moet "(?P<checkbox>(?:[^"]|\")*)" niet aangevinkt zijn$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-is-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" is (?:unchecked|not checked)$/]]></source>
-            <target><![CDATA[/^"(?P<checkbox>(?:[^"]|\\")*)" is niet aangevinkt$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" is (?:unchecked|not checked)$/]]></source>
+            <target><![CDATA[/^"(?P<checkbox>(?:[^"]|\")*)" is niet aangevinkt$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
@@ -135,24 +135,24 @@
             <target><![CDATA[/^moet (?:|ik )op de homepage zijn$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^moet de url overeenkomen met (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^moet de url overeenkomen met (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^moet het element "(?P<element>[^"]*)" "(?P<value>(?:[^"]|\\")*)" bevatten$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^moet het element "(?P<element>[^"]*)" "(?P<value>(?:[^"]|\")*)" bevatten$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-not-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^moet het element "(?P<element>[^"]*)" niet "(?P<value>(?:[^"]|\\")*)" bevatten$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^moet het element "(?P<element>[^"]*)" niet "(?P<value>(?:[^"]|\")*)" bevatten$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^moet (?:|ik )"(?P<text>(?:[^"]|\\")*)" zien in "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^moet (?:|ik )"(?P<text>(?:[^"]|\")*)" zien in "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^moet (?:|ik )de tekst "(?P<text>(?:[^"]|\\")*)" niet zien in "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^moet (?:|ik )de tekst "(?P<text>(?:[^"]|\")*)" niet zien in "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/pl.xliff
+++ b/i18n/pl.xliff
@@ -23,92 +23,92 @@
             <target><![CDATA[/^(?:|że )przejdę na kolejną stronę$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|że )nacisnę przycisk "(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|że )nacisnę przycisk "(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|że )kliknę na link "(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|że )kliknę na link "(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|że )wypełnię pole "(?P<field>(?:[^"]|\\")*)" wartością "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|że )wypełnię pole "(?P<field>(?:[^"]|\")*)" wartością "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|że )wpiszę "(?P<value>(?:[^"]|\\")*)" w polu "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|że )wpiszę "(?P<value>(?:[^"]|\")*)" w polu "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|że )wypełnię następujące pola:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|że )wybiorę opcję "(?P<option>(?:[^"]|\\")*)" w polu "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|że )wybiorę opcję "(?P<option>(?:[^"]|\")*)" w polu "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|że )dodatkowo zaznaczę opcję "(?P<option>(?:[^"]|\\")*)" w polu "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|że )dodatkowo zaznaczę opcję "(?P<option>(?:[^"]|\")*)" w polu "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|że )zaznaczę opcję "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|że )zaznaczę opcję "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|że )odznaczę opcję "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|że )odznaczę opcję "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|że )załączę plik "(?P<path>[^"]*)" w polu "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|że )załączę plik "(?P<path>[^"]*)" w polu "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|że )zobaczę tekst "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|że )zobaczę tekst "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^odpowiedź powinna zawierać tekst "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^odpowiedź powinna zawierać tekst "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|że )nie zobaczę tekstu "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|że )nie zobaczę tekstu "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^odpowiedź nie powinna zawierać tekstu "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^odpowiedź nie powinna zawierać tekstu "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^pole "(?P<field>(?:[^"]|\\")*)" powinno zawierać wartość "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^pole "(?P<field>(?:[^"]|\")*)" powinno zawierać wartość "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^pole "(?P<field>(?:[^"]|\\")*)" nie powinno zawierać wartości "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^pole "(?P<field>(?:[^"]|\")*)" nie powinno zawierać wartości "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^pole "(?P<checkbox>(?:[^"]|\\")*)" jest zaznaczone$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^pole "(?P<checkbox>(?:[^"]|\")*)" jest zaznaczone$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^pole "(?P<checkbox>(?:[^"]|\\")*)" jest odznaczone$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^pole "(?P<checkbox>(?:[^"]|\")*)" jest odznaczone$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
             <target><![CDATA[/^(?:|że )powinienem być na stronie "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:url|adres) powinien odpowiadać (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:url|adres) powinien odpowiadać (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^element "(?P<element>[^"]*)" powinien zawierać "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^element "(?P<element>[^"]*)" powinien zawierać "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|że )powinienem widzieć "(?P<text>(?:[^"]|\\")*)" wewnątrz elementu "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|że )powinienem widzieć "(?P<text>(?:[^"]|\")*)" wewnątrz elementu "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/pt-br.xliff
+++ b/i18n/pt-br.xliff
@@ -31,96 +31,96 @@
             <target><![CDATA[/^(?:|Eu )avanço uma página$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )pressiono o botão "(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )pressiono o botão "(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )sigo o link "(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )sigo o link "(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )preencho o campo "(?P<field>(?:[^"]|\\")*)" com "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )preencho o campo "(?P<field>(?:[^"]|\")*)" com "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with:$/]]></source>
-            <target><![CDATA[/^(?:|Eu )preencho o campo "(?P<field>(?:[^"]|\\")*)" com:$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with:$/]]></source>
+            <target><![CDATA[/^(?:|Eu )preencho o campo "(?P<field>(?:[^"]|\")*)" com:$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )preencho o valor "(?P<value>(?:[^"]|\\")*)" no campo "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )preencho o valor "(?P<value>(?:[^"]|\")*)" no campo "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|Eu )preencho os seguintes valores:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )seleciono a opção "(?P<option>(?:[^"]|\\")*)" no campo "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )seleciono a opção "(?P<option>(?:[^"]|\")*)" no campo "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )seleciono também "(?P<option>(?:[^"]|\\")*)" no campo "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )seleciono também "(?P<option>(?:[^"]|\")*)" no campo "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )marco a opção "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )marco a opção "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )desmarco a opção "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )desmarco a opção "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )anexo o arquivo "(?P<path>[^"]*)" no campo "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )anexo o arquivo "(?P<path>[^"]*)" no campo "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )devo ver o texto "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )devo ver o texto "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|Eu )devo ver o texto que coincide com (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|Eu )devo ver o texto que coincide com (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|Eu )não devo ver o texto que coincide com (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|Eu )não devo ver o texto que coincide com (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^a resposta deve conter "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^a resposta deve conter "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )não devo ver o texto "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )não devo ver o texto "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^a resposta não deve conter "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^a resposta não deve conter "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^o campo "(?P<field>(?:[^"]|\\")*)" deve conter o valor "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^o campo "(?P<field>(?:[^"]|\")*)" deve conter o valor "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^o campo "(?P<field>(?:[^"]|\\")*)" não deve conter o valor "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^o campo "(?P<field>(?:[^"]|\")*)" não deve conter o valor "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\\")*)" deve ser marcado$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\")*)" deve ser marcado$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-is-checked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" (?:is|should be) checked$/]]></source>
-            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\\")*)" deve estar marcado$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" (?:is|should be) checked$/]]></source>
+            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\")*)" deve estar marcado$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" should (?:be unchecked|not be checked)$/]]></source>
-            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\\")*)" deve ser desmarcado$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" should (?:be unchecked|not be checked)$/]]></source>
+            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\")*)" deve ser desmarcado$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-is-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" is (?:unchecked|not checked)$/]]></source>
-            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\\")*)" deve estar desmarcado$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" is (?:unchecked|not checked)$/]]></source>
+            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\")*)" deve estar desmarcado$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
@@ -131,24 +131,24 @@
             <target><![CDATA[/^(?:|Eu )devo estar na página inicial/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"([^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^a url deve coincidir com (?P<pattern>"([^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"([^"]|\")*")$/]]></source>
+            <target><![CDATA[/^a url deve coincidir com (?P<pattern>"([^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^o elemento "(?P<element>[^"]*)" deve conter "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^o elemento "(?P<element>[^"]*)" deve conter "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-not-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^o elemento "(?P<element>[^"]*)" não deve conter "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^o elemento "(?P<element>[^"]*)" não deve conter "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|Eu )eu devo ver o texto "(?P<text>(?:[^"]|\\")*)" no elemento "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|Eu )eu devo ver o texto "(?P<text>(?:[^"]|\")*)" no elemento "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|Eu )não devo ver o texto "(?P<text>(?:[^"]|\\")*)" no elemento "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|Eu )não devo ver o texto "(?P<text>(?:[^"]|\")*)" no elemento "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/pt.xliff
+++ b/i18n/pt.xliff
@@ -31,104 +31,104 @@
             <target><![CDATA[/^(?:|Eu )avancei uma página$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )pressiono "(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )pressiono "(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )sigo o link "(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )sigo o link "(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )preencho "(?P<field>(?:[^"]|\\")*)" com "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )preencho "(?P<field>(?:[^"]|\")*)" com "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )preencho "(?P<value>(?:[^"]|\\")*)" para "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )preencho "(?P<value>(?:[^"]|\")*)" para "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|Eu )preencho o seguinte:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )seleciono "(?P<option>(?:[^"]|\\")*)" de "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )seleciono "(?P<option>(?:[^"]|\")*)" de "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )seleciono também "(?P<option>(?:[^"]|\\")*)" de "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )seleciono também "(?P<option>(?:[^"]|\")*)" de "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )marco "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )marco "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )desmarco "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )desmarco "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )anexo o arquivo "(?P<path>[^"]*)" ao "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )anexo o arquivo "(?P<path>[^"]*)" ao "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )devo ver "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )devo ver "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|Eu )devo ver o texto que coincide com (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|Eu )devo ver o texto que coincide com (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|Eu )não devo ver o texto que coincide com (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|Eu )não devo ver o texto que coincide com (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^a resposta deve conter "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^a resposta deve conter "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )não devo ver "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )não devo ver "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^a resposta não deve conter "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^a resposta não deve conter "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^o campo "(?P<field>(?:[^"]|\\")*)" deve conter "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^o campo "(?P<field>(?:[^"]|\")*)" deve conter "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^o campo "(?P<field>(?:[^"]|\\")*)" não deve conter "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^o campo "(?P<field>(?:[^"]|\")*)" não deve conter "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\\")*)" deve (?:ser|estar) marcado$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\")*)" deve (?:ser|estar) marcado$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\\")*)" não deve (?:ser|estar) marcado$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\")*)" não deve (?:ser|estar) marcado$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
             <target><![CDATA[/^(?:|Eu )devo estar em "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^a (?i)url(?-i) deve coincidir com (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^a (?i)url(?-i) deve coincidir com (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^o elemento "(?P<element>[^"]*)" deve conter "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^o elemento "(?P<element>[^"]*)" deve conter "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|Eu )devo ver "(?P<text>(?:[^"]|\\")*)" no elemento "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|Eu )devo ver "(?P<text>(?:[^"]|\")*)" no elemento "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|Eu )não deveria de ver "(?P<text>(?:[^"]|\\")*)" no elemento "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|Eu )não deveria de ver "(?P<text>(?:[^"]|\")*)" no elemento "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/ro.xliff
+++ b/i18n/ro.xliff
@@ -31,100 +31,100 @@
             <target><![CDATA[/^(?:|Eu )merg la pagina următoare$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )apăs "(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )apăs "(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )urmez "(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )urmez "(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )completez "(?P<field>(?:[^"]|\\")*)" cu "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )completez "(?P<field>(?:[^"]|\")*)" cu "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with:$/]]></source>
-            <target><![CDATA[/^(?:|Eu )completez "(?P<field>(?:[^"]|\\")*)" cu:$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with:$/]]></source>
+            <target><![CDATA[/^(?:|Eu )completez "(?P<field>(?:[^"]|\")*)" cu:$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )completez cu "(?P<value>(?:[^"]|\\")*)" pentru "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )completez cu "(?P<value>(?:[^"]|\")*)" pentru "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|Eu ) completez următoarele:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )selectez "(?P<option>(?:[^"]|\\")*)" din "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )selectez "(?P<option>(?:[^"]|\")*)" din "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )selectez în plus "(?P<option>(?:[^"]|\\")*)" din "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )selectez în plus "(?P<option>(?:[^"]|\")*)" din "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )bifez "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )bifez "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )debifez "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )debifez "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )atașez fișierul "(?P<path>[^"]*)" la "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )atașez fișierul "(?P<path>[^"]*)" la "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )ar trebui să văd "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )ar trebui să văd "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|Eu )ar trebui să văd un text care coincide cu (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|Eu )ar trebui să văd un text care coincide cu (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|Eu )ar trebui să văd un text care coincide cu (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|Eu )ar trebui să văd un text care coincide cu (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^răspunsul ar trebui să conțină "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^răspunsul ar trebui să conțină "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|Eu )nu ar trebui să văd "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|Eu )nu ar trebui să văd "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^răspunsul nu ar trebui să conțină "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^răspunsul nu ar trebui să conțină "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^câmpul "(?P<field>(?:[^"]|\\")*)" ar trebui să conțină "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^câmpul "(?P<field>(?:[^"]|\")*)" ar trebui să conțină "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^câmpul "(?P<field>(?:[^"]|\\")*)" nu ar trebui să conțină "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^câmpul "(?P<field>(?:[^"]|\")*)" nu ar trebui să conțină "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^căsuța "(?P<checkbox>(?:[^"]|\\")*)" ar trebui bifată$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^căsuța "(?P<checkbox>(?:[^"]|\")*)" ar trebui bifată$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-is-checked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" (?:is|should be) checked$/]]></source>
-            <target><![CDATA[/^căsuța "(?P<checkbox>(?:[^"]|\\")*)" este bifată$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" (?:is|should be) checked$/]]></source>
+            <target><![CDATA[/^căsuța "(?P<checkbox>(?:[^"]|\")*)" este bifată$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" should (?:be unchecked|not be checked)$/]]></source>
-            <target><![CDATA[/^căsuța "(?P<checkbox>(?:[^"]|\\")*)" ar trebui să fie nebifată$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" should (?:be unchecked|not be checked)$/]]></source>
+            <target><![CDATA[/^căsuța "(?P<checkbox>(?:[^"]|\")*)" ar trebui să fie nebifată$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^căsuța "(?P<checkbox>(?:[^"]|\\")*)" ar trebui să nu fie bifată$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^căsuța "(?P<checkbox>(?:[^"]|\")*)" ar trebui să nu fie bifată$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-is-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" is (?:unchecked|not checked)$/]]></source>
-            <target><![CDATA[/^căsuța "(?P<checkbox>(?:[^"]|\\")*)" este nebifată$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" is (?:unchecked|not checked)$/]]></source>
+            <target><![CDATA[/^căsuța "(?P<checkbox>(?:[^"]|\")*)" este nebifată$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
@@ -135,24 +135,24 @@
             <target><![CDATA[/^(?:|Eu )ar trebui să fiu pe prima pagină/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:url|адрес) ar trebui să aibă tiparul (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:url|адрес) ar trebui să aibă tiparul (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^elementul "(?P<element>[^"]*)" ar trebui să conțină "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^elementul "(?P<element>[^"]*)" ar trebui să conțină "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-not-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^elementul "(?P<element>[^"]*)" ar trebui să nu conțină "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^elementul "(?P<element>[^"]*)" ar trebui să nu conțină "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|Eu )ar trebui să văd textul "(?P<text>(?:[^"]|\\")*)" în elementul "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|Eu )ar trebui să văd textul "(?P<text>(?:[^"]|\")*)" în elementul "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|Eu )ar trebui să nu văd textul "(?P<text>(?:[^"]|\\")*)" în elementul "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|Eu )ar trebui să nu văd textul "(?P<text>(?:[^"]|\")*)" în elementul "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/ru.xliff
+++ b/i18n/ru.xliff
@@ -31,100 +31,100 @@
             <target><![CDATA[/^(?:|я )перехожу на одну страницу вперед$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|я )нажимаю "(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|я )нажимаю "(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|я )кликаю по ссылке "(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|я )кликаю по ссылке "(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|я )заполняю поле "(?P<field>(?:[^"]|\\")*)" значением "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|я )заполняю поле "(?P<field>(?:[^"]|\")*)" значением "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with:$/]]></source>
-            <target><![CDATA[/^(?:|я )заполняю поле "(?P<field>(?:[^"]|\\")*)" значениями:$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with:$/]]></source>
+            <target><![CDATA[/^(?:|я )заполняю поле "(?P<field>(?:[^"]|\")*)" значениями:$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|я )ввожу "(?P<value>(?:[^"]|\\")*)" в поле "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|я )ввожу "(?P<value>(?:[^"]|\")*)" в поле "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|я )ввожу следующие значения:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|я )выбираю "(?P<option>(?:[^"]|\\")*)" в поле "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|я )выбираю "(?P<option>(?:[^"]|\")*)" в поле "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|я )дополнительно выбираю "(?P<option>(?:[^"]|\\")*)" в поле "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|я )дополнительно выбираю "(?P<option>(?:[^"]|\")*)" в поле "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|я )ставлю галочку "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|я )ставлю галочку "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|я )снимаю галочку "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|я )снимаю галочку "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|я )выбираю файл "(?P<path>[^"]*)" в поле "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|я )выбираю файл "(?P<path>[^"]*)" в поле "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|я )должен видеть "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|я )должен видеть "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|я )должен видеть текст соответствующий (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|я )должен видеть текст соответствующий (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|я )не должен видеть текст соответствующий (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|я )не должен видеть текст соответствующий (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^тело ответа должно содержать "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^тело ответа должно содержать "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|я )не должен видеть "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|я )не должен видеть "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^тело ответа не должно содержать "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^тело ответа не должно содержать "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^поле "(?P<field>(?:[^"]|\\")*)" должно содержать "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^поле "(?P<field>(?:[^"]|\")*)" должно содержать "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^поле "(?P<field>(?:[^"]|\\")*)" не должно содержать "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^поле "(?P<field>(?:[^"]|\")*)" не должно содержать "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^галочка "(?P<checkbox>(?:[^"]|\\")*)" должна быть отмечена$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^галочка "(?P<checkbox>(?:[^"]|\")*)" должна быть отмечена$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-is-checked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" (?:is|should be) checked$/]]></source>
-            <target><![CDATA[/^галочка "(?P<checkbox>(?:[^"]|\\")*)" отмечена$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" (?:is|should be) checked$/]]></source>
+            <target><![CDATA[/^галочка "(?P<checkbox>(?:[^"]|\")*)" отмечена$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" should (?:be unchecked|not be checked)$/]]></source>
-            <target><![CDATA[/^галочка "(?P<checkbox>(?:[^"]|\\")*)" не должна быть отмечена$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" should (?:be unchecked|not be checked)$/]]></source>
+            <target><![CDATA[/^галочка "(?P<checkbox>(?:[^"]|\")*)" не должна быть отмечена$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^галочка "(?P<checkbox>(?:[^"]|\\")*)" должна быть не отмечена$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^галочка "(?P<checkbox>(?:[^"]|\")*)" должна быть не отмечена$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-is-unchecked">
-            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\\")*)" is (?:unchecked|not checked)$/]]></source>
-            <target><![CDATA[/^галочка "(?P<checkbox>(?:[^"]|\\")*)" не отмечена$/]]></target>
+            <source><![CDATA[/^the checkbox "(?P<checkbox>(?:[^"]|\")*)" is (?:unchecked|not checked)$/]]></source>
+            <target><![CDATA[/^галочка "(?P<checkbox>(?:[^"]|\")*)" не отмечена$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
@@ -135,24 +135,24 @@
             <target><![CDATA[/^(?:|я )должен быть на главной странице/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:url|адрес) должен соответствовать (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:url|адрес) должен соответствовать (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^элемент "(?P<element>[^"]*)" должен содержать "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^элемент "(?P<element>[^"]*)" должен содержать "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-not-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^элемент "(?P<element>[^"]*)" не должен содержать "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^элемент "(?P<element>[^"]*)" не должен содержать "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|я )должен видеть "(?P<text>(?:[^"]|\\")*)" внутри элемента "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|я )должен видеть "(?P<text>(?:[^"]|\")*)" внутри элемента "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|я )не должен видеть "(?P<text>(?:[^"]|\\")*)" внутри элемента "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|я )не должен видеть "(?P<text>(?:[^"]|\")*)" внутри элемента "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/sk.xliff
+++ b/i18n/sk.xliff
@@ -23,100 +23,100 @@
             <target><![CDATA[/^(?:prej|pôj)dem o jednu stránku (?:vpred|vopred|dopredu)$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:stlačím|stisnem|kliknem na) (?:tlačídko|tlačidlo|tlačítko) "(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:stlačím|stisnem|kliknem na) (?:tlačídko|tlačidlo|tlačítko) "(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^kliknem na(?:| odkaz| link) "(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^kliknem na(?:| odkaz| link) "(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:vyplním|zadám do) "(?P<field>(?:[^"]|\\")*)" (?:hodnotou|hodnotu) "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:vyplním|zadám do) "(?P<field>(?:[^"]|\")*)" (?:hodnotou|hodnotu) "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:zadám|vyplním) "(?P<value>(?:[^"]|\\")*)" (?:hodnotu|hodnotou) "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:zadám|vyplním) "(?P<value>(?:[^"]|\")*)" (?:hodnotu|hodnotou) "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^vyplním formulár(?:| nasledujúco):$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:vyberiem|zvolím)(?:| možnosť) "(?P<option>(?:[^"]|\\")*)" z "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:vyberiem|zvolím)(?:| možnosť) "(?P<option>(?:[^"]|\")*)" z "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^ešte (?:vyberiem|zvolím)(?:| možnosť) "(?P<option>(?:[^"]|\\")*)" z "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^ešte (?:vyberiem|zvolím)(?:| možnosť) "(?P<option>(?:[^"]|\")*)" z "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:zaškrtnem|označím) "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:zaškrtnem|označím) "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:odškrtnem|odznačím) "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:odškrtnem|odznačím) "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:vyberiem|zvolím|zadám|nahrajem|načítam) súbor "(?P<path>[^"]*)" do "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:vyberiem|zvolím|zadám|nahrajem|načítam) súbor "(?P<path>[^"]*)" do "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:by som mal(?:|a)|mal(?:|a) by som|musím) (?:|u)vidieť(?:| text| hlášku| správu) "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:by som mal(?:|a)|mal(?:|a) by som|musím) (?:|u)vidieť(?:| text| hlášku| správu) "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:mal(?:|a) by som|by som mal(?:|a)|musím) (?:|u)vidieť(?:| text| hlášku| správu) zodpovedajúcu(?:| vzoru) (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:mal(?:|a) by som|by som mal(?:|a)|musím) (?:|u)vidieť(?:| text| hlášku| správu) zodpovedajúcu(?:| vzoru) (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:nemal(?:|a) by som|by som nemal(?:|a)|nesmiem) (?:|u)vidieť(?:| text| hlášku| správu) zodpovedajúcu(?:| vzoru) (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:nemal(?:|a) by som|by som nemal(?:|a)|nesmiem) (?:|u)vidieť(?:| text| hlášku| správu) zodpovedajúcu(?:| vzoru) (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:odpoveď|stránka) (?:musí|by mala) obsahovať(?:| text) "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:odpoveď|stránka) (?:musí|by mala) obsahovať(?:| text) "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:nemal(?:|a) by som|by som nemal(?:|a))|nesmiem) (?:|u)vidieť(?:| text) "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:nemal(?:|a) by som|by som nemal(?:|a))|nesmiem) (?:|u)vidieť(?:| text) "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:odpoveď|stránka) (?:by nemala|nesmie) obsahovať(?:| text) "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:odpoveď|stránka) (?:by nemala|nesmie) obsahovať(?:| text) "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^pole "(?P<field>(?:[^"]|\\")*)" (?:musí obsahovať|malo by obsahovať|by malo obsahovať|obsahuje)(?:| text| hodnotu) "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^pole "(?P<field>(?:[^"]|\")*)" (?:musí obsahovať|malo by obsahovať|by malo obsahovať|obsahuje)(?:| text| hodnotu) "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^pole "(?P<field>(?:[^"]|\\")*)" (?:nesmie obsahovať|nemalo by obsahovať|by nemalo obsahovať|neobsahuje)(?:| text| hodnotu) "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^pole "(?P<field>(?:[^"]|\")*)" (?:nesmie obsahovať|nemalo by obsahovať|by nemalo obsahovať|neobsahuje)(?:| text| hodnotu) "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^(?:pole|políčko|zaškrtávacie pole|zaškrtávacie políčko) "(?P<checkbox>(?:[^"]|\\")*)" (?:by malo byť|je) (?:zaškrtnuté|označené)$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^(?:pole|políčko|zaškrtávacie pole|zaškrtávacie políčko) "(?P<checkbox>(?:[^"]|\")*)" (?:by malo byť|je) (?:zaškrtnuté|označené)$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^(?:pole|políčko|zaškrtávacie pole|zaškrtávacie políčko) "(?P<checkbox>(?:[^"]|\\")*)" (?:by nemalo byť|nie je) (?:zaškrtnuté|označené)$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^(?:pole|políčko|zaškrtávacie pole|zaškrtávacie políčko) "(?P<checkbox>(?:[^"]|\")*)" (?:by nemalo byť|nie je) (?:zaškrtnuté|označené)$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
             <target><![CDATA[/^(?:mal(?:|a) by som byť|by som mal(?:|a) byť|som|musím byť) na(?:| stránke) "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:url|adresa|link) (?:by mal(?:|a)|mal(?:|a) by|musí) zodpovedať(?:| vzoru) (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:url|adresa|link) (?:by mal(?:|a)|mal(?:|a) by|musí) zodpovedať(?:| vzoru) (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^element "(?P<element>[^"]*)" (?:by mal|mal by|musí) obsahovať(?:| text| hodnotu) "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^element "(?P<element>[^"]*)" (?:by mal|mal by|musí) obsahovať(?:| text| hodnotu) "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:mal(?:|a) by som|by som mal(?:|a)|musím) (?:|u)vidieť(?:| text| hodnotu| hlášku| správu) "(?P<text>(?:[^"]|\\")*)" v elemente "(?P<element>[^"]*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:mal(?:|a) by som|by som mal(?:|a)|musím) (?:|u)vidieť(?:| text| hodnotu| hlášku| správu) "(?P<text>(?:[^"]|\")*)" v elemente "(?P<element>[^"]*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/sv.xliff
+++ b/i18n/sv.xliff
@@ -23,88 +23,88 @@
             <target><![CDATA[/^(?:|jag )gå en sida framåt$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jag )trycka "(?P<button>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jag )trycka "(?P<button>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jag )följa "(?P<link>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jag )följa "(?P<link>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jag )fylla in "(?P<field>(?:[^"]|\\")*)" med "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jag )fylla in "(?P<field>(?:[^"]|\")*)" med "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jag )fylla in "(?P<value>(?:[^"]|\\")*)" för "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jag )fylla in "(?P<value>(?:[^"]|\")*)" för "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|jag )fylla in följande:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jag )välja "(?P<option>(?:[^"]|\\")*)" från "(?P<select>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jag )välja "(?P<option>(?:[^"]|\")*)" från "(?P<select>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jag )markera "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jag )markera "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jag )avmarkera "(?P<option>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jag )avmarkera "(?P<option>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jag )bifoga filen "(?P<path>[^"]*)" till "(?P<field>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jag )bifoga filen "(?P<path>[^"]*)" till "(?P<field>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jag )skulle se "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jag )skulle se "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^responsen skulle innehålla "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^responsen skulle innehålla "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|jag )skulle inte se "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|jag )skulle inte se "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^responsen skulle inte innehålla "(?P<text>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^responsen skulle inte innehålla "(?P<text>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^fältet "(?P<field>(?:[^"]|\\")*)" skulle inehålla "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^fältet "(?P<field>(?:[^"]|\")*)" skulle inehålla "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^fältet "(?P<field>(?:[^"]|\\")*)" skulle inte innehålla "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^fältet "(?P<field>(?:[^"]|\")*)" skulle inte innehålla "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^kryssrutan "(?P<checkbox>(?:[^"]|\\")*)" skulle vara markerat$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^kryssrutan "(?P<checkbox>(?:[^"]|\")*)" skulle vara markerat$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^kryssrutan "(?P<checkbox>(?:[^"]|\\")*)" skulle inte vara markerat$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^kryssrutan "(?P<checkbox>(?:[^"]|\")*)" skulle inte vara markerat$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
             <target><![CDATA[/^(?:|jag )skulle vara på "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^webbadressen skulle matcha (?P<pattern>"(?:[^"]|\\")*")$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^webbadressen skulle matcha (?P<pattern>"(?:[^"]|\")*")$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^elementen "(?P<element>[^"]*)" skulle innehålla "(?P<value>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^elementen "(?P<element>[^"]*)" skulle innehålla "(?P<value>(?:[^"]|\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^(?:|jag )skulle se "(?P<text>(?:[^"]|\\")*)" i "(?P<element>[^"]*)" elementet$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^(?:|jag )skulle se "(?P<text>(?:[^"]|\")*)" i "(?P<element>[^"]*)" elementet$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>

--- a/i18n/zh-CN.xliff
+++ b/i18n/zh-CN.xliff
@@ -23,97 +23,97 @@
             <target><![CDATA[/^(?:|我)前进了一页$/]]></target>
         </trans-unit>
         <trans-unit id="i-press-button">
-            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|我)点击了“(?P<button>(?:[^"]|\\")*)”按钮$/]]></target>
+            <source><![CDATA[/^(?:|I )press "(?P<button>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|我)点击了“(?P<button>(?:[^"]|\")*)”按钮$/]]></target>
         </trans-unit>
         <trans-unit id="i-follow-link">
-            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|我)点击了“(?P<link>(?:[^"]|\\")*)”链接$/]]></target>
+            <source><![CDATA[/^(?:|I )follow "(?P<link>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|我)点击了“(?P<link>(?:[^"]|\")*)”链接$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-field-with-value">
-            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|我)在“(?P<field>(?:[^"]|\\")*)”文本框内填写了“(?P<value>(?:[^"]|\\")*)”$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<field>(?:[^"]|\")*)" with "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|我)在“(?P<field>(?:[^"]|\")*)”文本框内填写了“(?P<value>(?:[^"]|\")*)”$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-value-for-field">
-            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|我)内填写了“(?P<value>(?:[^"]|\\")*)”到“(?P<field>(?:[^"]|\\")*)”文本框$/]]></target>
+            <source><![CDATA[/^(?:|I )fill in "(?P<value>(?:[^"]|\")*)" for "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|我)内填写了“(?P<value>(?:[^"]|\")*)”到“(?P<field>(?:[^"]|\")*)”文本框$/]]></target>
         </trans-unit>
         <trans-unit id="i-fill-in-the-following">
             <source><![CDATA[/^(?:|I )fill in the following:$/]]></source>
             <target><![CDATA[/^(?:|我)使用以下数据输入:$/]]></target>
         </trans-unit>
         <trans-unit id="i-select-option-from-select">
-            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|我)在“(?P<select>(?:[^"]|\\")*)”选择框里面选择了“(?P<option>(?:[^"]|\\")*)”$/]]></target>
+            <source><![CDATA[/^(?:|I )select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|我)在“(?P<select>(?:[^"]|\")*)”选择框里面选择了“(?P<option>(?:[^"]|\")*)”$/]]></target>
         </trans-unit>
         <trans-unit id="i-additionally-select-option-from-select">
-            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|我)在“(?P<select>(?:[^"]|\\")*)”选择框里面添加了“(?P<option>(?:[^"]|\\")*)”选择$/]]></target>
+            <source><![CDATA[/^(?:|I )additionally select "(?P<option>(?:[^"]|\")*)" from "(?P<select>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|我)在“(?P<select>(?:[^"]|\")*)”选择框里面添加了“(?P<option>(?:[^"]|\")*)”选择$/]]></target>
         </trans-unit>
         <trans-unit id="i-check-option">
-            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|我)选中了“(?P<option>(?:[^"]|\\")*)”选项$/]]></target>
+            <source><![CDATA[/^(?:|I )check "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|我)选中了“(?P<option>(?:[^"]|\")*)”选项$/]]></target>
         </trans-unit>
         <trans-unit id="i-uncheck-option">
-            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|我)取消了“(?P<option>(?:[^"]|\\")*)”选项$/]]></target>
+            <source><![CDATA[/^(?:|I )uncheck "(?P<option>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|我)取消了“(?P<option>(?:[^"]|\")*)”选项$/]]></target>
         </trans-unit>
         <trans-unit id="i-attach-the-file-to-field">
-            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|我)添加了文件“(?P<path>[^"]*)”到“(?P<field>(?:[^"]|\\")*)”文件选择框$/]]></target>
+            <source><![CDATA[/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|我)添加了文件“(?P<path>[^"]*)”到“(?P<field>(?:[^"]|\")*)”文件选择框$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|我)应该可以看见包含“(?P<text>(?:[^"]|\\")*)”的内容$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|我)应该可以看见包含“(?P<text>(?:[^"]|\")*)”的内容$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-contain">
-            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^响应应该包含“(?P<text>(?:[^"]|\\")*)”的内容$/]]></target>
+            <source><![CDATA[/^the response should contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^响应应该包含“(?P<text>(?:[^"]|\")*)”的内容$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^(?:|我)应该不能看见包含“(?P<text>(?:[^"]|\\")*)”的内容$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^(?:|我)应该不能看见包含“(?P<text>(?:[^"]|\")*)”的内容$/]]></target>
         </trans-unit>
         <trans-unit id="the-response-should-not-contain">
-            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^响应不应该包含“(?P<text>(?:[^"]|\\")*)”的内容$/]]></target>
+            <source><![CDATA[/^the response should not contain "(?P<text>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^响应不应该包含“(?P<text>(?:[^"]|\")*)”的内容$/]]></target>
 
         </trans-unit>
         <trans-unit id="the-field-should-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^“(?P<field>(?:[^"]|\\")*)”文本框应该包含值“(?P<value>(?:[^"]|\\")*)”$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^“(?P<field>(?:[^"]|\")*)”文本框应该包含值“(?P<value>(?:[^"]|\")*)”$/]]></target>
         </trans-unit>
         <trans-unit id="the-field-should-not-contain-value">
-            <source><![CDATA[/^the "(?P<field>(?:[^"]|\\")*)" field should not contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^“(?P<field>(?:[^"]|\\")*)”文本框应该不包含值“(?P<value>(?:[^"]|\\")*)”$/]]></target>
+            <source><![CDATA[/^the "(?P<field>(?:[^"]|\")*)" field should not contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^“(?P<field>(?:[^"]|\")*)”文本框应该不包含值“(?P<value>(?:[^"]|\")*)”$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^“(?P<checkbox>(?:[^"]|\\")*)”选项框应该已经选中了$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should be checked$/]]></source>
+            <target><![CDATA[/^“(?P<checkbox>(?:[^"]|\")*)”选项框应该已经选中了$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
-            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^“(?P<checkbox>(?:[^"]|\\")*)”选项框应该还没有选中$/]]></target>
+            <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\")*)" checkbox should not be checked$/]]></source>
+            <target><![CDATA[/^“(?P<checkbox>(?:[^"]|\")*)”选项框应该还没有选中$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>
             <target><![CDATA[/^(?:|我)应该到了“(?P<page>[^\s]+)”$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?i)url(?-i) 应该匹配“(?P<pattern>"(?:[^"]|\\")*")”$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?i)url(?-i) 应该匹配“(?P<pattern>"(?:[^"]|\")*")”$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
-            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^“(?P<element>[^"]*)”元素应该包含“(?P<value>(?:[^"]|\\")*)”内容$/]]></target>
+            <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\")*)"$/]]></source>
+            <target><![CDATA[/^“(?P<element>[^"]*)”元素应该包含“(?P<value>(?:[^"]|\")*)”内容$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^“(?P<element>[^"]*)”元素应该有“(?P<value>(?:[^"]|\\")*)”内容$/]]></target>
+            <source><![CDATA[/^(?:|I )should see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^“(?P<element>[^"]*)”元素应该有“(?P<value>(?:[^"]|\")*)”内容$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-not-see-text-in-element">
-            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
-            <target><![CDATA[/^“(?P<element>[^"]*)”元素应该没有“(?P<value>(?:[^"]|\\")*)”内容$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see "(?P<text>(?:[^"]|\")*)" in the "(?P<element>[^"]*)" element$/]]></source>
+            <target><![CDATA[/^“(?P<element>[^"]*)”元素应该没有“(?P<value>(?:[^"]|\")*)”内容$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-see-element">
             <source><![CDATA[/^(?:|I )should see an? "(?P<element>[^"]*)" element$/]]></source>
@@ -144,13 +144,13 @@
             <target><![CDATA[/^显示最后一次响应$/]]></target>
         </trans-unit>
         <trans-unit id="-should-see-text-matching">
-            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|我)应该可以看见文本内容匹配“(?P<pattern>"(?:[^"]|\\")*")”$/]]></target>
+            <source><![CDATA[/^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|我)应该可以看见文本内容匹配“(?P<pattern>"(?:[^"]|\")*")”$/]]></target>
 
         </trans-unit>
         <trans-unit id="-should-not-see-text-matching">
-            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/]]></source>
-            <target><![CDATA[/^(?:|我)应该可以看见文本内容不匹配“(?P<pattern>"(?:[^"]|\\")*")”$/]]></target>
+            <source><![CDATA[/^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\")*")$/]]></source>
+            <target><![CDATA[/^(?:|我)应该可以看见文本内容不匹配“(?P<pattern>"(?:[^"]|\")*")”$/]]></target>
         </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
## Summary

Every non-English translation catalog under `i18n/*.xliff` (17 files: `cs`, `da`, `de`, `es`, `fr`, `hu`, `id`, `it`, `ja`, `nl`, `pl`, `pt`, `pt-br`, `ro`, `ru`, `sk`, `sv`, `zh-CN`) has a `<source>` (and, where the same construct appears, `<target>`) entry that is a byte-for-byte mismatch with the actual regex Behat looks up as a translation key, for every step whose pattern contains an escaped-quote alternative such as `(?:[^"]|\\")*`. In practice this is most of `MinkContext`'s string-argument steps: `press`, `follow`, `fill in`, `select`, `check`, `uncheck`, `attach the file`, `should (not) see`, `the field should (not) contain`, `the element should (not) contain`, etc.

## Root cause

`MinkContext`'s step patterns are declared as PHP single-quoted string literals, e.g.:

```php
#[\Behat\Step\When('/^(?:|I )press "(?P<button>(?:[^"]|\\")*)"$/')]
```

PHP decodes the `\\"` escape sequence in a single-quoted string to a single backslash followed by a literal quote *before* Behat ever sees the string. That decoded string — one backslash, one quote — is what Behat's translator uses as the lookup key (`msgid`) against each catalog's `<source>`.

The `i18n/*.xliff` files are raw XML `CDATA`, not PHP string literals, so there is no such decoding step for their contents. Every affected `<source>` still contained the literal two-backslash sequence `\\"` (i.e. an actual backslash character followed by a quote character, four bytes wide: `\`, `\`, `"`), rather than the one-backslash sequence Behat actually looks for.

Because Symfony's translator does an exact match on the `msgid`, the lookup silently fails for all of these entries. The practical effect: any step that uses this escaped-quote pattern is never translated in any locale — writing a `# language: xx` feature file and using, say, "I press" translated into that language for these steps doesn't work, with no error, just a step definition that doesn't match.

## Fix

Strip the redundant backslash so each `<source>` (and `<target>`, where it also used the pattern) exactly mirrors the string PHP actually decodes from the corresponding attribute in `MinkContext.php`. Applied identically across all 17 locale files — this is the same bug repeated in every catalog, not a per-language issue.

Verified byte-for-byte for a sample unit (`i-press-button`) via `ReflectionClass`/`ReflectionAttribute` against the live `MinkContext::pressButton` step definition (both hex-dumped to 43 identical bytes) rather than by inspection alone.

## Test plan

- [x] Confirmed via `hex_dump`/`ReflectionAttribute` comparison that the fixed `fr.xliff` `<source>` for `i-press-button` is now byte-identical to the actual PHP-decoded regex used by `MinkContext::pressButton`.
- [x] Confirmed no remaining occurrences of the buggy double-backslash sequence in any of the 17 catalogs.
- [x] Added `features/search.fr.feature`, a French translation of the existing `search.feature`, exercising 4 of the affected steps. Confirmed it reproduces the regression against the pre-fix catalog (6 of 8 steps undefined) and passes fully with the fix (8/8 steps, full suite green against Wikipedia) — see comment below for details.